### PR TITLE
fix: use backend stream proxy for video playback

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,22 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Stream proxy — unbuffered, long timeout for video streaming
+    location /api/stream/ {
+        proxy_pass http://streamvault-api:3001/api/stream/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Range $http_range;
+        proxy_set_header If-Range $http_if_range;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
     # API proxy to backend (same Docker network)
     location /api/ {
         proxy_pass http://streamvault-api:3001/api/;

--- a/src/features/player/api.ts
+++ b/src/features/player/api.ts
@@ -1,14 +1,17 @@
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { api } from '@lib/api';
 import type { StreamUrlResponse, HistoryUpdateRequest } from '@shared/types/api';
 
 export function useStreamUrl(type: string, id: string) {
-  return useQuery({
-    queryKey: ['stream', 'url', type, id],
-    queryFn: () => api<StreamUrlResponse>(`/stream/url/${type}/${id}`),
-    enabled: !!type && !!id,
-    staleTime: 5 * 60 * 1000,
-  });
+  const enabled = !!type && !!id;
+  const data: StreamUrlResponse | undefined = enabled
+    ? {
+        url: `/api/stream/${type}/${id}`,
+        format: type === 'live' ? 'm3u8' : 'mp4',
+        isLive: type === 'live',
+      }
+    : undefined;
+  return { data, isLoading: false, error: null };
 }
 
 export function useUpdateHistory() {


### PR DESCRIPTION
## Summary
- `useStreamUrl` now constructs `/api/stream/:type/:id` proxy URL client-side (no API call needed)
- Nginx: dedicated `/api/stream/` location block with `proxy_buffering off` and 1-hour timeout for long VOD streams
- Companion to streamvault-backend PR — backend now proxies video bytes instead of returning direct Xtream URLs

## Test plan
- [ ] Navigate to VOD item → video plays (no "Playback Error")
- [ ] Navigate to Live channel → HLS stream loads via HLS.js
- [ ] Seek forward/backward in VOD → Range requests work
- [ ] Browser Network tab: no requests to Xtream host directly, no credentials visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)