### PR TITLE
feat: Phase 2 — latest movies by language, See All grid, fixes

### DIFF
--- a/src/features/home/api.ts
+++ b/src/features/home/api.ts
@@ -1,5 +1,8 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useQuery, useQueries } from '@tanstack/react-query';
 import { api } from '@lib/api';
+import { useVODCategories } from '@features/vod/api';
+import { groupCategoriesByLanguage } from '@shared/utils/categoryParser';
 import type {
   XtreamLiveStream,
   XtreamVODStream,
@@ -39,4 +42,99 @@ export function useRecentlyAdded<T extends RecentlyAddedType>(type: T) {
     },
     staleTime: 5 * 60 * 1000, // 5 min
   });
+}
+
+// --- Language-grouped latest movies ---
+
+function parseAdded(val: string): number {
+  const num = Number(val);
+  if (!isNaN(num) && num > 1e9) return num; // Unix timestamp
+  const parsed = Date.parse(val);
+  return isNaN(parsed) ? 0 : parsed / 1000;
+}
+
+export interface LanguageMovieRail {
+  language: string;
+  languageKey: string;
+  items: XtreamVODStream[];
+}
+
+const MAX_LANGUAGES = 6;
+const CATEGORIES_PER_LANGUAGE = 2;
+const ITEMS_PER_LANGUAGE = 15;
+
+export function useLatestMoviesByLanguage() {
+  const { data: vodCategories, isLoading: categoriesLoading } = useVODCategories();
+
+  // Group VOD categories by language (priority-sorted)
+  const languageGroups = useMemo(
+    () => groupCategoriesByLanguage(vodCategories ?? [], 'movies').slice(0, MAX_LANGUAGES),
+    [vodCategories],
+  );
+
+  // Build a flat list of queries: up to 2 category fetches per language
+  const queryDefs = useMemo(() => {
+    const defs: { languageKey: string; language: string; categoryId: string }[] = [];
+    for (const group of languageGroups) {
+      for (const cat of group.movies.slice(0, CATEGORIES_PER_LANGUAGE)) {
+        defs.push({ languageKey: group.languageKey, language: group.language, categoryId: cat.id });
+      }
+    }
+    return defs;
+  }, [languageGroups]);
+
+  const queries = useQueries({
+    queries: queryDefs.map((def) => ({
+      queryKey: ['vod', 'streams', def.categoryId],
+      queryFn: () => api<XtreamVODStream[]>(`/vod/streams/${def.categoryId}`),
+      enabled: !categoriesLoading && queryDefs.length > 0,
+      staleTime: 2 * 60 * 60 * 1000,
+    })),
+  });
+
+  const isLoading = categoriesLoading || queries.some((q) => q.isLoading);
+
+  // Merge streams per language, sort by added DESC, take top N
+  const rails = useMemo<LanguageMovieRail[]>(() => {
+    if (queries.length === 0) return [];
+
+    const byLanguage = new Map<string, { language: string; languageKey: string; items: XtreamVODStream[] }>();
+
+    for (let i = 0; i < queryDefs.length; i++) {
+      const def = queryDefs[i]!;
+      const data = queries[i]?.data;
+      if (!data) continue;
+
+      if (!byLanguage.has(def.languageKey)) {
+        byLanguage.set(def.languageKey, { language: def.language, languageKey: def.languageKey, items: [] });
+      }
+      byLanguage.get(def.languageKey)!.items.push(...data);
+    }
+
+    // Maintain priority order from languageGroups
+    const result: LanguageMovieRail[] = [];
+    for (const group of languageGroups) {
+      const entry = byLanguage.get(group.languageKey);
+      if (!entry || entry.items.length === 0) continue;
+
+      // Sort by added DESC and dedupe by stream_id
+      const seen = new Set<number>();
+      const unique = entry.items.filter((item) => {
+        if (seen.has(item.stream_id)) return false;
+        seen.add(item.stream_id);
+        return true;
+      });
+
+      unique.sort((a, b) => parseAdded(b.added) - parseAdded(a.added));
+      result.push({
+        language: entry.language,
+        languageKey: entry.languageKey,
+        items: unique.slice(0, ITEMS_PER_LANGUAGE),
+      });
+    }
+
+    return result;
+  }, [queries, queryDefs, languageGroups]);
+
+  return { rails, isLoading };
 }

--- a/src/features/home/components/HomePage.tsx
+++ b/src/features/home/components/HomePage.tsx
@@ -5,7 +5,7 @@ import { HeroBanner, type HeroItem } from '@shared/components/HeroBanner';
 import { ContentRail } from '@shared/components/ContentRail';
 import { FocusableCard } from '@shared/components/FocusableCard';
 import { ContinueWatching } from './ContinueWatching';
-import { useRecentlyAdded } from '../api';
+import { useRecentlyAdded, useLatestMoviesByLanguage } from '../api';
 import { usePlayerStore } from '@lib/store';
 import type { XtreamVODStream, XtreamSeriesItem, XtreamLiveStream } from '@shared/types/api';
 
@@ -13,17 +13,18 @@ export function HomePage() {
   const navigate = useNavigate();
   const playStream = usePlayerStore((s) => s.playStream);
 
-  const { data: recentMovies, isLoading: moviesLoading } = useRecentlyAdded('vod');
+  const { rails: languageRails, isLoading: moviesLoading } = useLatestMoviesByLanguage();
   const { data: recentSeries, isLoading: seriesLoading } = useRecentlyAdded('series');
   const { data: recentLive, isLoading: liveLoading } = useRecentlyAdded('live');
 
-  // Build hero items from recent movies/series with images
+  // Build hero items from first language rail's movies + series
   const heroItems = useMemo<HeroItem[]>(() => {
     const items: HeroItem[] = [];
 
-    // Add top-rated movies
-    if (recentMovies) {
-      for (const m of recentMovies.slice(0, 3)) {
+    // Add top movies from the first language rail
+    const firstRail = languageRails[0];
+    if (firstRail) {
+      for (const m of firstRail.items.slice(0, 3)) {
         if (m.stream_icon) {
           items.push({
             id: m.stream_id,
@@ -56,7 +57,7 @@ export function HomePage() {
     }
 
     return items.slice(0, 5);
-  }, [recentMovies, recentSeries]);
+  }, [languageRails, recentSeries]);
 
   const handleVodClick = (item: XtreamVODStream) => {
     navigate({ to: '/vod/$vodId', params: { vodId: String(item.stream_id) } });
@@ -81,23 +82,27 @@ export function HomePage() {
         {/* Continue Watching */}
         <ContinueWatching />
 
-        {/* Recently Added Movies */}
-        <ContentRail
-          title="Recently Added Movies"
-          isLoading={moviesLoading}
-          isEmpty={!recentMovies?.length}
-        >
-          {(recentMovies ?? []).map((item) => (
-            <FocusableCard
-              key={item.stream_id}
-              image={item.stream_icon}
-              title={item.name}
-              subtitle={item.rating ? `⭐ ${item.rating}` : undefined}
-              aspectRatio="poster"
-              onClick={() => handleVodClick(item)}
-            />
-          ))}
-        </ContentRail>
+        {/* Language-grouped Latest Movies */}
+        {languageRails.map((rail) => (
+          <ContentRail
+            key={rail.languageKey}
+            title={`Latest ${rail.language} Movies`}
+            seeAllTo={`/language/${rail.languageKey}`}
+            isLoading={moviesLoading}
+            isEmpty={!rail.items.length}
+          >
+            {rail.items.map((item) => (
+              <FocusableCard
+                key={item.stream_id}
+                image={item.stream_icon}
+                title={item.name}
+                subtitle={item.rating ? `⭐ ${item.rating}` : undefined}
+                aspectRatio="poster"
+                onClick={() => handleVodClick(item)}
+              />
+            ))}
+          </ContentRail>
+        ))}
 
         {/* Recently Added Series */}
         <ContentRail

--- a/src/features/language/CategoryGridPage.tsx
+++ b/src/features/language/CategoryGridPage.tsx
@@ -1,0 +1,249 @@
+import { useState, useMemo } from 'react';
+import { useParams, useNavigate, Link } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@lib/api';
+import { useVODCategories } from '@features/vod/api';
+import { useSeriesCategories } from '@features/series/api';
+import { useLiveCategories } from '@features/live/api';
+import { SortFilterBar } from '@features/vod/components/SortFilterBar';
+import { ContentCard } from '@shared/components/ContentCard';
+import { SkeletonGrid } from '@shared/components/Skeleton';
+import { EmptyState } from '@shared/components/EmptyState';
+import { Badge } from '@shared/components/Badge';
+import { PageTransition } from '@shared/components/PageTransition';
+import { sortContent, SORT_OPTIONS, type SortOption } from '@shared/utils/sortContent';
+import { filterContent, DEFAULT_FILTERS, type FilterState } from '@shared/utils/filterContent';
+import { collectAllGenres, parseGenres } from '@shared/utils/parseGenres';
+import { useDebounce } from '@shared/hooks/useDebounce';
+import { usePlayerStore } from '@lib/store';
+import type { XtreamVODStream, XtreamSeriesItem, XtreamLiveStream } from '@shared/types/api';
+
+type ContentType = 'vod' | 'series' | 'live' | null;
+
+export function CategoryGridPage() {
+  const { lang, categoryId } = useParams({ strict: false }) as { lang?: string; categoryId?: string };
+  const navigate = useNavigate();
+  const playStream = usePlayerStore((s) => s.playStream);
+  const language = lang ? lang.charAt(0).toUpperCase() + lang.slice(1) : '';
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sort, setSort] = useState<SortOption>(SORT_OPTIONS[0]!);
+  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+  const debouncedSearch = useDebounce(searchQuery);
+
+  // Load all category lists to determine content type
+  const { data: vodCategories } = useVODCategories();
+  const { data: seriesCategories } = useSeriesCategories();
+  const { data: liveCategories } = useLiveCategories();
+
+  // Determine which content type this category belongs to
+  const { contentType, categoryName } = useMemo<{ contentType: ContentType; categoryName: string }>(() => {
+    if (!categoryId) return { contentType: null, categoryName: '' };
+
+    const vodMatch = vodCategories?.find((c) => c.category_id === categoryId);
+    if (vodMatch) return { contentType: 'vod', categoryName: vodMatch.category_name };
+
+    const seriesMatch = seriesCategories?.find((c) => c.category_id === categoryId);
+    if (seriesMatch) return { contentType: 'series', categoryName: seriesMatch.category_name };
+
+    const liveMatch = liveCategories?.find((c) => c.category_id === categoryId);
+    if (liveMatch) return { contentType: 'live', categoryName: liveMatch.category_name };
+
+    return { contentType: null, categoryName: '' };
+  }, [categoryId, vodCategories, seriesCategories, liveCategories]);
+
+  // Fetch streams based on content type
+  const { data: vodStreams, isLoading: vodLoading } = useQuery({
+    queryKey: ['vod', 'streams', categoryId],
+    queryFn: () => api<XtreamVODStream[]>(`/vod/streams/${categoryId}`),
+    enabled: contentType === 'vod' && !!categoryId,
+    staleTime: 2 * 60 * 60 * 1000,
+  });
+
+  const { data: seriesList, isLoading: seriesLoading } = useQuery({
+    queryKey: ['series', 'list', categoryId],
+    queryFn: () => api<XtreamSeriesItem[]>(`/series/list/${categoryId}`),
+    enabled: contentType === 'series' && !!categoryId,
+    staleTime: 2 * 60 * 60 * 1000,
+  });
+
+  const { data: liveStreams, isLoading: liveLoading } = useQuery({
+    queryKey: ['live', 'streams', categoryId],
+    queryFn: () => api<XtreamLiveStream[]>(`/live/streams/${categoryId}`),
+    enabled: contentType === 'live' && !!categoryId,
+    staleTime: 30 * 60 * 1000,
+  });
+
+  const isLoading = vodLoading || seriesLoading || liveLoading;
+
+  // Collect genres (vod/series only)
+  const genres = useMemo(() => {
+    if (contentType === 'vod' && vodStreams) {
+      return collectAllGenres(vodStreams as unknown as Array<{ genre?: string }>);
+    }
+    if (contentType === 'series' && seriesList) {
+      return collectAllGenres(seriesList as unknown as Array<{ genre?: string }>);
+    }
+    return [];
+  }, [contentType, vodStreams, seriesList]);
+
+  // Process VOD streams
+  const processedVod = useMemo(() => {
+    if (contentType !== 'vod' || !vodStreams) return [];
+    let result = [...vodStreams];
+    if (debouncedSearch) {
+      const q = debouncedSearch.toLowerCase();
+      result = result.filter((s) => s.name.toLowerCase().includes(q));
+    }
+    result = filterContent(result as unknown as Record<string, unknown>[], filters) as unknown as typeof result;
+    result = sortContent(result as unknown as Record<string, unknown>[], sort.field, sort.direction) as unknown as typeof result;
+    return result;
+  }, [contentType, vodStreams, debouncedSearch, filters, sort]);
+
+  // Process series
+  const processedSeries = useMemo(() => {
+    if (contentType !== 'series' || !seriesList) return [];
+    let result = [...seriesList];
+    if (debouncedSearch) {
+      const q = debouncedSearch.toLowerCase();
+      result = result.filter((s) => s.name.toLowerCase().includes(q));
+    }
+    result = filterContent(result as unknown as Record<string, unknown>[], filters) as unknown as typeof result;
+    result = sortContent(result as unknown as Record<string, unknown>[], sort.field, sort.direction) as unknown as typeof result;
+    return result;
+  }, [contentType, seriesList, debouncedSearch, filters, sort]);
+
+  // Process live streams (search only, no sort/filter)
+  const processedLive = useMemo(() => {
+    if (contentType !== 'live' || !liveStreams) return [];
+    let result = [...liveStreams];
+    if (debouncedSearch) {
+      const q = debouncedSearch.toLowerCase();
+      result = result.filter((s) => s.name.toLowerCase().includes(q));
+    }
+    return result;
+  }, [contentType, liveStreams, debouncedSearch]);
+
+  const totalItems = processedVod.length + processedSeries.length + processedLive.length;
+
+  if (!lang || !categoryId) {
+    return (
+      <PageTransition>
+        <div className="px-6 lg:px-10 py-20 text-center">
+          <p className="text-text-muted text-lg">Category not found</p>
+        </div>
+      </PageTransition>
+    );
+  }
+
+  return (
+    <PageTransition>
+      <div className="px-6 lg:px-10 py-6">
+        {/* Breadcrumb */}
+        <nav className="flex items-center gap-2 text-sm text-text-muted mb-4">
+          <Link
+            to="/"
+            className="hover:text-text-primary transition-colors"
+          >
+            Home
+          </Link>
+          <span>/</span>
+          <Link
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            to={'/language/$lang' as any}
+            params={{ lang }}
+            className="hover:text-text-primary transition-colors capitalize"
+          >
+            {language}
+          </Link>
+          <span>/</span>
+          <span className="text-text-primary">{categoryName || `Category ${categoryId}`}</span>
+        </nav>
+
+        <h1 className="font-display text-2xl font-bold text-text-primary mb-4">
+          {categoryName || `Category ${categoryId}`}
+        </h1>
+
+        {/* Search */}
+        <div className="flex items-center gap-4 mb-4">
+          <input
+            type="text"
+            placeholder={`Search ${contentType === 'live' ? 'channels' : contentType === 'series' ? 'series' : 'movies'}...`}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full max-w-xs px-4 py-2 bg-surface-raised border border-border rounded-lg text-text-primary placeholder:text-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-teal/50 focus:border-teal-dim transition-all"
+          />
+        </div>
+
+        {/* Sort/Filter bar (only for vod/series, not live) */}
+        {contentType !== 'live' && (
+          <SortFilterBar
+            sort={sort}
+            onSortChange={setSort}
+            filters={filters}
+            onFiltersChange={setFilters}
+            genres={genres}
+          />
+        )}
+
+        {/* Grid */}
+        {isLoading ? (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+            <SkeletonGrid count={18} aspectRatio="poster" />
+          </div>
+        ) : totalItems === 0 ? (
+          <EmptyState
+            title="No content found"
+            message="Try adjusting your search or filters"
+            icon="content"
+          />
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+            {/* VOD items */}
+            {processedVod.map((movie) => (
+              <ContentCard
+                key={movie.stream_id}
+                image={movie.stream_icon}
+                title={movie.name}
+                subtitle={parseGenres(movie.container_extension).length > 0 ? movie.container_extension.toUpperCase() : undefined}
+                badge={
+                  movie.rating_5based > 0 ? (
+                    <Badge variant="warning">{movie.rating_5based.toFixed(1)} ★</Badge>
+                  ) : undefined
+                }
+                onClick={() => navigate({ to: '/vod/$vodId', params: { vodId: String(movie.stream_id) } })}
+              />
+            ))}
+
+            {/* Series items */}
+            {processedSeries.map((series) => (
+              <ContentCard
+                key={series.series_id}
+                image={series.cover}
+                title={series.name}
+                subtitle={series.releaseDate ? series.releaseDate.slice(0, 4) : undefined}
+                badge={
+                  series.rating_5based > 0 ? (
+                    <Badge variant="warning">{series.rating_5based.toFixed(1)} ★</Badge>
+                  ) : undefined
+                }
+                onClick={() => navigate({ to: '/series/$seriesId', params: { seriesId: String(series.series_id) } })}
+              />
+            ))}
+
+            {/* Live items */}
+            {processedLive.map((channel) => (
+              <ContentCard
+                key={channel.stream_id}
+                image={channel.stream_icon}
+                title={channel.name}
+                aspectRatio="square"
+                onClick={() => playStream(String(channel.stream_id), 'live', channel.name)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </PageTransition>
+  );
+}

--- a/src/features/language/LanguageHubPage.tsx
+++ b/src/features/language/LanguageHubPage.tsx
@@ -128,6 +128,7 @@ export function LanguageHubPage() {
               <ContentRail
                 key={rail.category.id}
                 title={rail.category.name || rail.category.originalName}
+                seeAllTo={`/language/${lang}/category/${rail.category.id}`}
               >
                 {rail.items.map((item) => (
                   <FocusableCard
@@ -161,6 +162,7 @@ export function LanguageHubPage() {
               <ContentRail
                 key={rail.category.id}
                 title={rail.category.name || rail.category.originalName}
+                seeAllTo={`/language/${lang}/category/${rail.category.id}`}
               >
                 {rail.items.map((item) => (
                   <FocusableCard
@@ -194,6 +196,7 @@ export function LanguageHubPage() {
               <ContentRail
                 key={rail.category.id}
                 title={rail.category.name || rail.category.originalName}
+                seeAllTo={`/language/${lang}/category/${rail.category.id}`}
               >
                 {rail.items.map((item) => (
                   <FocusableCard

--- a/src/features/player/api.ts
+++ b/src/features/player/api.ts
@@ -7,7 +7,7 @@ export function useStreamUrl(type: string, id: string) {
   const data: StreamUrlResponse | undefined = enabled
     ? {
         url: `/api/stream/${type}/${id}`,
-        format: type === 'live' ? 'm3u8' : 'mp4',
+        format: type === 'live' ? 'ts' : 'mp4',
         isLive: type === 'live',
       }
     : undefined;

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -76,8 +76,31 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
 
       setIsReady(false);
       const isHls = format === 'm3u8' || url.endsWith('.m3u8');
+      let hlsRetryCount = 0;
+      const HLS_MAX_RETRIES = 3;
+      let fallbackAttempted = false;
 
-      if (isHls && Hls.isSupported()) {
+      const startDirectPlayback = () => {
+        destroyHls();
+        video.src = url;
+        video.onloadeddata = () => {
+          setIsReady(true);
+          if (startTime > 0 && !isLive) video.currentTime = startTime;
+          if (autoPlay) video.play().catch(() => {});
+        };
+        video.onerror = () => {
+          // If direct playback fails and we haven't tried HLS yet, attempt HLS fallback
+          if (!fallbackAttempted && !isHls && Hls.isSupported()) {
+            fallbackAttempted = true;
+            startHlsPlayback();
+          } else {
+            onError?.('Channel unavailable');
+          }
+        };
+        if (autoPlay) video.play().catch(() => {});
+      };
+
+      const startHlsPlayback = () => {
         destroyHls();
         const hls = new Hls({
           enableWorker: true,
@@ -112,32 +135,50 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
             if (data.type === Hls.ErrorTypes.MEDIA_ERROR) {
               hls.recoverMediaError();
             } else if (data.type === Hls.ErrorTypes.NETWORK_ERROR) {
-              onError?.('Network error - retrying...');
-              hls.startLoad();
+              hlsRetryCount++;
+              if (hlsRetryCount <= HLS_MAX_RETRIES) {
+                onError?.(`Network error - retry ${hlsRetryCount}/${HLS_MAX_RETRIES}...`);
+                hls.startLoad();
+              } else {
+                // HLS retries exhausted -- fall back to direct playback
+                if (!fallbackAttempted) {
+                  fallbackAttempted = true;
+                  startDirectPlayback();
+                } else {
+                  onError?.('Channel unavailable');
+                }
+              }
             } else {
-              onError?.(`Playback error: ${data.details}`);
-              destroyHls();
+              // Non-recoverable HLS error -- fall back to direct playback
+              if (!fallbackAttempted) {
+                fallbackAttempted = true;
+                startDirectPlayback();
+              } else {
+                onError?.('Channel unavailable');
+              }
             }
           }
         });
+      };
 
-        return () => destroyHls();
+      if (isHls && Hls.isSupported()) {
+        startHlsPlayback();
       } else if (isHls && video.canPlayType('application/vnd.apple.mpegurl')) {
+        // Native HLS support (Safari)
         video.src = url;
         setIsReady(true);
         if (startTime > 0 && !isLive) video.currentTime = startTime;
         if (autoPlay) video.play().catch(() => {});
       } else {
-        video.src = url;
-        video.onloadeddata = () => {
-          setIsReady(true);
-          if (startTime > 0) video.currentTime = startTime;
-          if (autoPlay) video.play().catch(() => {});
-        };
-        video.onerror = () => onError?.('Failed to load video');
+        // Direct playback for .ts, .mp4, or non-HLS streams
+        startDirectPlayback();
       }
 
-      return () => destroyHls();
+      return () => {
+        destroyHls();
+        video.onloadeddata = null;
+        video.onerror = null;
+      };
     }, [url, format, isLive, autoPlay, startTime, onError, onQualityLevelsReady, destroyHls]);
 
     useEffect(() => {

--- a/src/features/series/components/SeriesPage.tsx
+++ b/src/features/series/components/SeriesPage.tsx
@@ -55,43 +55,47 @@ export function SeriesPage() {
             <div key={i} className="h-8 w-20 bg-surface-raised rounded-lg animate-pulse" />
           ))}
         </div>
+      ) : !categories?.length ? (
+        <EmptyState title="No series available" message="Your provider doesn't include series content" icon="content" />
       ) : (
-        <div className="mb-4">
-          <CategoryGrid categories={categories || []} selectedId={selectedCategory || null} onSelect={setSelectedCategory} />
-        </div>
-      )}
+        <>
+          <div className="mb-4">
+            <CategoryGrid categories={categories || []} selectedId={selectedCategory || null} onSelect={setSelectedCategory} />
+          </div>
 
-      <div className="flex items-center gap-4 mb-4">
-        <input
-          type="text"
-          placeholder="Search series..."
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full max-w-xs px-4 py-2 bg-surface-raised border border-border rounded-lg text-text-primary placeholder:text-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-teal/50 focus:border-teal-dim transition-all"
-        />
-      </div>
-
-      <SortFilterBar sort={sort} onSortChange={setSort} filters={filters} onFiltersChange={setFilters} genres={genres} />
-
-      {listLoading ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
-          <SkeletonGrid count={12} aspectRatio="poster" />
-        </div>
-      ) : processedSeries.length === 0 ? (
-        <EmptyState title="No series found" message="Try adjusting your filters" icon="content" />
-      ) : (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
-          {processedSeries.map((series) => (
-            <ContentCard
-              key={series.series_id}
-              image={series.cover}
-              title={series.name}
-              subtitle={series.releaseDate ? series.releaseDate.slice(0, 4) : undefined}
-              badge={series.rating_5based > 0 ? <Badge variant="warning">{series.rating_5based.toFixed(1)} ★</Badge> : undefined}
-              onClick={() => navigate({ to: '/series/$seriesId', params: { seriesId: String(series.series_id) } })}
+          <div className="flex items-center gap-4 mb-4">
+            <input
+              type="text"
+              placeholder="Search series..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full max-w-xs px-4 py-2 bg-surface-raised border border-border rounded-lg text-text-primary placeholder:text-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-teal/50 focus:border-teal-dim transition-all"
             />
-          ))}
-        </div>
+          </div>
+
+          <SortFilterBar sort={sort} onSortChange={setSort} filters={filters} onFiltersChange={setFilters} genres={genres} />
+
+          {listLoading ? (
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+              <SkeletonGrid count={12} aspectRatio="poster" />
+            </div>
+          ) : processedSeries.length === 0 ? (
+            <EmptyState title="No series found" message="Try a different category" icon="content" />
+          ) : (
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+              {processedSeries.map((series) => (
+                <ContentCard
+                  key={series.series_id}
+                  image={series.cover}
+                  title={series.name}
+                  subtitle={series.releaseDate ? series.releaseDate.slice(0, 4) : undefined}
+                  badge={series.rating_5based > 0 ? <Badge variant="warning">{series.rating_5based.toFixed(1)} ★</Badge> : undefined}
+                  onClick={() => navigate({ to: '/series/$seriesId', params: { seriesId: String(series.series_id) } })}
+                />
+              ))}
+            </div>
+          )}
+        </>
       )}
     </div>
     </PageTransition>

--- a/src/routes/_authenticated/language/$lang_.category.$categoryId.tsx
+++ b/src/routes/_authenticated/language/$lang_.category.$categoryId.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { CategoryGridPage } from '@features/language/CategoryGridPage';
+
+export const Route = createFileRoute(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  '/_authenticated/language/$lang_/category/$categoryId' as any,
+)({
+  component: CategoryGridPage,
+});

--- a/src/shared/components/Sidebar.tsx
+++ b/src/shared/components/Sidebar.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from 'react';
 import { Link, useMatchRoute } from '@tanstack/react-router';
 import { useUIStore } from '@lib/store';
+import { useSeriesCategories } from '@features/series/api';
 
-const navItems = [
+const allNavItems = [
   { to: '/' as const, label: 'Home', icon: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6' },
   { to: '/live' as const, label: 'Live TV', icon: 'M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z' },
   { to: '/vod' as const, label: 'Movies', icon: 'M7 4v16M17 4v16M3 8h4m10 0h4M3 12h18M3 16h4m10 0h4M4 20h16a1 1 0 001-1V5a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1z' },
@@ -14,6 +16,14 @@ const navItems = [
 export function Sidebar() {
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
   const matchRoute = useMatchRoute();
+  const { data: seriesCategories, isLoading: seriesLoading } = useSeriesCategories();
+
+  // Hide Series nav when we know for sure there are no series categories
+  const navItems = useMemo(() => {
+    const hasSeries = seriesLoading || (seriesCategories && seriesCategories.length > 0);
+    if (hasSeries) return allNavItems;
+    return allNavItems.filter((item) => item.to !== '/series');
+  }, [seriesCategories, seriesLoading]);
 
   return (
     <aside


### PR DESCRIPTION
## Summary
- **Live TV fix**: Default to TS format, add fallback between direct/HLS playback with circuit breaker, retry HLS errors 3x
- **Series handling**: Show "provider doesn't include series" when empty, hide Series nav link
- **Latest movies by language**: Home page shows per-language rails (Telugu, Hindi, English, etc.) sorted by recency
- **See All grid page**: New `/language/:lang/category/:categoryId` route with search, sort, filter controls
- **See All links**: Wired from LanguageHubPage and HomePage ContentRails

## Test plan
- [ ] Live TV: click any channel → video plays or shows clear error after retries
- [ ] Series: page shows "provider doesn't include series" if no categories (or hides nav link)
- [ ] Home: shows "Latest Telugu Movies", "Latest Hindi Movies" rails instead of generic "Recently Added"
- [ ] Click "See All →" on any rail → grid page with breadcrumbs + search/sort/filter
- [ ] `/language/telugu/category/770` loads category grid correctly
- [ ] Build succeeds: `npm run build` no errors

Depends on: srinivas-kotha/streamvault-backend PR (deploy backend first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)