### PR TITLE
feat: auto-login for LAN users via IP bypass

### DIFF
--- a/src/features/auth/api.ts
+++ b/src/features/auth/api.ts
@@ -25,3 +25,16 @@ export async function checkAuth(): Promise<boolean> {
     return false;
   }
 }
+
+export async function autoLogin(): Promise<{ username: string } | null> {
+  try {
+    const res = await fetch('/api/auth/auto-login', { credentials: 'include' });
+    if (res.ok) {
+      const data = await res.json();
+      return { username: data.username };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -4,11 +4,18 @@ import { SpatialNavigationProvider } from '@shared/providers/SpatialNavigationPr
 import { useAuthStore } from '@lib/store';
 import { useAuthCheck } from '@features/auth/hooks/useAuth';
 import { useBackNavigation } from '@shared/hooks/useBackNavigation';
+import { autoLogin } from '@features/auth/api';
 
 export const Route = createFileRoute('/_authenticated')({
-  beforeLoad: () => {
-    const { isAuthenticated } = useAuthStore.getState();
+  beforeLoad: async () => {
+    const { isAuthenticated, setAuth } = useAuthStore.getState();
     if (!isAuthenticated) {
+      // Try IP-based auto-login (LAN bypass)
+      const result = await autoLogin();
+      if (result) {
+        setAuth(result.username);
+        return;
+      }
       throw redirect({ to: '/login' });
     }
   },


### PR DESCRIPTION
## Summary
- Add `autoLogin()` function that calls backend `/api/auth/auto-login`
- Modify `_authenticated` route to try auto-login before redirecting to login page
- Home network devices (TV) get authenticated transparently — no login screen

## Depends on
- streamvault-backend PR (feat/lan-auth-bypass) must be deployed first

## Test plan
- [ ] From trusted IP: open app → auto-login succeeds → lands on home page (no login screen)
- [ ] From untrusted IP: open app → auto-login fails → redirects to login page as before
- [ ] Normal login flow still works for remote users
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)