### PR TITLE
feat: TV/remote UX fixes for D-pad navigation

### DIFF
--- a/src/features/player/components/PlayerControls.tsx
+++ b/src/features/player/components/PlayerControls.tsx
@@ -146,7 +146,7 @@ export function PlayerControls({
         )}
 
         {/* Volume */}
-        <div className="relative flex items-center" onMouseEnter={() => setShowVolume(true)} onMouseLeave={() => setShowVolume(false)}>
+        <div className="relative flex items-center" onMouseEnter={() => setShowVolume(true)} onMouseLeave={() => setShowVolume(false)} onFocus={() => setShowVolume(true)} onBlur={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) setShowVolume(false); }}>
           <FocusableButton onClick={onMuteToggle} className="p-1.5 text-white/70 hover:text-white transition-colors">
             {isMuted || volume === 0 ? (
               <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/src/features/player/hooks/usePlayerKeyboard.ts
+++ b/src/features/player/hooks/usePlayerKeyboard.ts
@@ -29,6 +29,20 @@ export function usePlayerKeyboard({
       const video = playerRef.current?.getVideo();
       if (!video) return;
 
+      // For arrow keys: only handle if no specific UI control is focused.
+      // This lets spatial navigation work for D-pad users navigating player controls.
+      // When focus is on body, video, or the player container, arrows control playback.
+      const isArrowKey = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key);
+      if (isArrowKey) {
+        const active = document.activeElement;
+        const isGenericFocus =
+          !active ||
+          active === document.body ||
+          active === video ||
+          active.tagName === 'VIDEO';
+        if (!isGenericFocus) return; // Let spatial nav handle it
+      }
+
       switch (e.key) {
         case ' ':
         case 'k':

--- a/src/features/search/components/SearchPage.tsx
+++ b/src/features/search/components/SearchPage.tsx
@@ -1,14 +1,56 @@
-import { useState, useMemo, useRef, useEffect } from 'react';
+import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { useSearch } from '../api';
 import { useDebounce } from '@shared/hooks/useDebounce';
 import { ContentCard } from '@shared/components/ContentCard';
 import { SkeletonGrid } from '@shared/components/Skeleton';
 import { EmptyState } from '@shared/components/EmptyState';
-import { usePlayerStore } from '@lib/store';
+import { usePlayerStore, useUIStore } from '@lib/store';
 import { PageTransition } from '@shared/components/PageTransition';
+import { useFocusable, FocusContext } from '@noriginmedia/norigin-spatial-navigation';
 
 type TabType = 'all' | 'live' | 'vod' | 'series';
+
+function FocusableTab({
+  label,
+  count,
+  isActive,
+  showCount,
+  onSelect,
+}: {
+  label: string;
+  count: number;
+  isActive: boolean;
+  showCount: boolean;
+  onSelect: () => void;
+}) {
+  const inputMode = useUIStore((s) => s.inputMode);
+  const { ref, focused } = useFocusable({
+    onEnterPress: onSelect,
+  });
+  const showFocus = focused && inputMode === 'keyboard';
+
+  return (
+    <button
+      ref={ref}
+      onClick={onSelect}
+      className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-all min-h-[44px] ${
+        isActive
+          ? 'text-teal border-b-2 border-teal bg-teal/5'
+          : showFocus
+            ? 'text-text-primary bg-surface-raised ring-2 ring-teal/50'
+            : 'text-text-secondary hover:text-text-primary hover:bg-surface-raised'
+      }`}
+    >
+      {label}
+      {showCount && (
+        <span className={`ml-1.5 text-xs ${isActive ? 'text-teal/70' : 'text-text-muted'}`}>
+          ({count})
+        </span>
+      )}
+    </button>
+  );
+}
 
 export function SearchPage() {
   const [query, setQuery] = useState('');
@@ -51,11 +93,22 @@ export function SearchPage() {
     navigate({ to: '/series/$seriesId', params: { seriesId: String(seriesId) } });
   };
 
+  const handleTabSelect = useCallback((key: TabType) => {
+    setActiveTab(key);
+  }, []);
+
   const hasQuery = debouncedQuery.length >= 2;
   const showLoading = hasQuery && (isLoading || isFetching);
   const showResults = hasQuery && data && !isLoading;
   const showEmpty = showResults && counts.all === 0;
   const showPrompt = !hasQuery;
+
+  // Spatial nav context for search tabs
+  const { ref: tabsRef, focusKey: tabsFocusKey } = useFocusable({
+    focusKey: 'search-tabs',
+    trackChildren: true,
+    saveLastFocusedChild: true,
+  });
 
   return (
     <PageTransition>
@@ -92,28 +145,22 @@ export function SearchPage() {
         )}
       </div>
 
-      {/* Tabs */}
+      {/* Tabs — wrapped in spatial nav context */}
       {hasQuery && (
-        <div className="flex gap-1 border-b border-white/10 pb-px">
-          {tabs.map((tab) => (
-            <button
-              key={tab.key}
-              onClick={() => setActiveTab(tab.key)}
-              className={`px-4 py-2 text-sm font-medium rounded-t-lg transition-all ${
-                activeTab === tab.key
-                  ? 'text-teal border-b-2 border-teal bg-teal/5'
-                  : 'text-text-secondary hover:text-text-primary hover:bg-surface-raised'
-              }`}
-            >
-              {tab.label}
-              {showResults && (
-                <span className={`ml-1.5 text-xs ${activeTab === tab.key ? 'text-teal/70' : 'text-text-muted'}`}>
-                  ({tab.count})
-                </span>
-              )}
-            </button>
-          ))}
-        </div>
+        <FocusContext.Provider value={tabsFocusKey}>
+          <div ref={tabsRef} className="flex gap-1 border-b border-white/10 pb-px">
+            {tabs.map((tab) => (
+              <FocusableTab
+                key={tab.key}
+                label={tab.label}
+                count={tab.count}
+                isActive={activeTab === tab.key}
+                showCount={!!showResults}
+                onSelect={() => handleTabSelect(tab.key)}
+              />
+            ))}
+          </div>
+        </FocusContext.Provider>
       )}
 
       {/* Loading */}

--- a/src/shared/components/HorizontalScroll.tsx
+++ b/src/shared/components/HorizontalScroll.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useEffect, useCallback, type ReactNode } from 'react';
+import { useUIStore } from '@lib/store';
 
 interface HorizontalScrollProps {
   children: ReactNode;
@@ -9,6 +10,7 @@ export function HorizontalScroll({ children, className = '' }: HorizontalScrollP
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
+  const inputMode = useUIStore((s) => s.inputMode);
 
   const checkScroll = useCallback(() => {
     const el = scrollRef.current;
@@ -40,14 +42,22 @@ export function HorizontalScroll({ children, className = '' }: HorizontalScrollP
     });
   };
 
+  const isKeyboard = inputMode === 'keyboard';
+
+  // In keyboard mode, arrows are always visible; in mouse mode, only on hover
+  const arrowOpacity = isKeyboard
+    ? 'opacity-100'
+    : 'opacity-0 group-hover/scroll:opacity-100';
+
   return (
     <div className={`group/scroll relative ${className}`}>
       {/* Left arrow */}
       {canScrollLeft && (
         <button
           onClick={() => scroll('left')}
-          className="absolute left-0 top-1/2 -translate-y-1/2 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-obsidian/80 border border-border-subtle text-text-primary opacity-0 group-hover/scroll:opacity-100 transition-opacity duration-200 hover:bg-surface-raised hover:border-teal/30"
+          className={`absolute left-0 top-1/2 -translate-y-1/2 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-obsidian/80 border border-border-subtle text-text-primary transition-opacity duration-200 hover:bg-surface-raised hover:border-teal/30 ${arrowOpacity}`}
           aria-label="Scroll left"
+          tabIndex={-1}
         >
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
@@ -59,7 +69,6 @@ export function HorizontalScroll({ children, className = '' }: HorizontalScrollP
       <div
         ref={scrollRef}
         className="flex gap-4 overflow-x-auto scrollbar-hide scroll-smooth"
-        style={{ scrollSnapType: 'x mandatory' }}
       >
         {children}
       </div>
@@ -68,8 +77,9 @@ export function HorizontalScroll({ children, className = '' }: HorizontalScrollP
       {canScrollRight && (
         <button
           onClick={() => scroll('right')}
-          className="absolute right-0 top-1/2 -translate-y-1/2 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-obsidian/80 border border-border-subtle text-text-primary opacity-0 group-hover/scroll:opacity-100 transition-opacity duration-200 hover:bg-surface-raised hover:border-teal/30"
+          className={`absolute right-0 top-1/2 -translate-y-1/2 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-obsidian/80 border border-border-subtle text-text-primary transition-opacity duration-200 hover:bg-surface-raised hover:border-teal/30 ${arrowOpacity}`}
           aria-label="Scroll right"
+          tabIndex={-1}
         >
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />

--- a/src/shared/components/TopNav.tsx
+++ b/src/shared/components/TopNav.tsx
@@ -72,46 +72,12 @@ export function TopNav() {
         <TopNavFocusGroup languages={languages} matchRoute={matchRoute} />
 
         {/* Profile */}
-        <div className="relative ml-4 flex-shrink-0">
-          <button
-            onClick={(e) => { e.stopPropagation(); setProfileOpen(!profileOpen); }}
-            aria-expanded={profileOpen}
-            aria-haspopup="menu"
-            className="flex items-center gap-2 px-3 py-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-raised/50 transition-all min-h-[48px]"
-          >
-            <div className="w-8 h-8 rounded-full bg-gradient-to-br from-teal to-indigo flex items-center justify-center text-sm font-bold text-obsidian">
-              {username?.[0]?.toUpperCase() ?? 'U'}
-            </div>
-            <span className="text-sm hidden lg:block">{username}</span>
-          </button>
-
-          {profileOpen && (
-            <div role="menu" className="absolute right-0 top-full mt-2 w-48 py-2 bg-surface-raised border border-border rounded-lg shadow-xl z-[60]">
-              <Link
-                to="/favorites"
-                role="menuitem"
-                className="block px-4 py-2.5 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors"
-              >
-                Favorites
-              </Link>
-              <Link
-                to="/history"
-                role="menuitem"
-                className="block px-4 py-2.5 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors"
-              >
-                Watch History
-              </Link>
-              <hr className="my-1 border-border-subtle" />
-              <button
-                role="menuitem"
-                onClick={() => logoutMutation.mutate()}
-                className="w-full text-left px-4 py-2.5 text-sm text-error hover:bg-surface-hover transition-colors"
-              >
-                Sign Out
-              </button>
-            </div>
-          )}
-        </div>
+        <ProfileMenu
+          username={username}
+          profileOpen={profileOpen}
+          setProfileOpen={setProfileOpen}
+          onLogout={() => logoutMutation.mutate()}
+        />
       </nav>
     </header>
   );
@@ -193,5 +159,99 @@ function TopNavFocusGroup({ languages, matchRoute }: { languages: string[]; matc
         } />
       </div>
     </FocusContext.Provider>
+  );
+}
+
+function ProfileMenu({
+  username,
+  profileOpen,
+  setProfileOpen,
+  onLogout,
+}: {
+  username: string | null;
+  profileOpen: boolean;
+  setProfileOpen: (v: boolean) => void;
+  onLogout: () => void;
+}) {
+  const navigate = useNavigate();
+  const inputMode = useUIStore((s) => s.inputMode);
+
+  const { ref: profileBtnRef, focused: profileFocused } = useFocusable({
+    onEnterPress: () => setProfileOpen(!profileOpen),
+  });
+
+  const { ref: favRef, focused: favFocused } = useFocusable({
+    onEnterPress: () => { navigate({ to: '/favorites' }); setProfileOpen(false); },
+  });
+
+  const { ref: histRef, focused: histFocused } = useFocusable({
+    onEnterPress: () => { navigate({ to: '/history' }); setProfileOpen(false); },
+  });
+
+  const { ref: logoutRef, focused: logoutFocused } = useFocusable({
+    onEnterPress: onLogout,
+  });
+
+  const showProfileFocus = profileFocused && inputMode === 'keyboard';
+
+  return (
+    <div className="relative ml-4 flex-shrink-0">
+      <button
+        ref={profileBtnRef}
+        onClick={(e) => { e.stopPropagation(); setProfileOpen(!profileOpen); }}
+        aria-expanded={profileOpen}
+        aria-haspopup="menu"
+        className={`flex items-center gap-2 px-3 py-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-raised/50 transition-all min-h-[48px] ${
+          showProfileFocus ? 'ring-2 ring-teal/50 text-text-primary' : ''
+        }`}
+      >
+        <div className="w-8 h-8 rounded-full bg-gradient-to-br from-teal to-indigo flex items-center justify-center text-sm font-bold text-obsidian">
+          {username?.[0]?.toUpperCase() ?? 'U'}
+        </div>
+        <span className="text-sm hidden lg:block">{username}</span>
+      </button>
+
+      {profileOpen && (
+        <div role="menu" className="absolute right-0 top-full mt-2 w-48 py-2 bg-surface-raised border border-border rounded-lg shadow-xl z-[60]">
+          <Link
+            ref={favRef}
+            to="/favorites"
+            role="menuitem"
+            className={`block px-4 py-2.5 text-sm min-h-[44px] flex items-center transition-colors ${
+              favFocused && inputMode === 'keyboard'
+                ? 'text-text-primary bg-teal/10 ring-1 ring-teal/40'
+                : 'text-text-secondary hover:text-text-primary hover:bg-surface-hover'
+            }`}
+          >
+            Favorites
+          </Link>
+          <Link
+            ref={histRef}
+            to="/history"
+            role="menuitem"
+            className={`block px-4 py-2.5 text-sm min-h-[44px] flex items-center transition-colors ${
+              histFocused && inputMode === 'keyboard'
+                ? 'text-text-primary bg-teal/10 ring-1 ring-teal/40'
+                : 'text-text-secondary hover:text-text-primary hover:bg-surface-hover'
+            }`}
+          >
+            Watch History
+          </Link>
+          <hr className="my-1 border-border-subtle" />
+          <button
+            ref={logoutRef}
+            role="menuitem"
+            onClick={onLogout}
+            className={`w-full text-left px-4 py-2.5 text-sm min-h-[44px] transition-colors ${
+              logoutFocused && inputMode === 'keyboard'
+                ? 'text-error bg-error/10 ring-1 ring-error/40'
+                : 'text-error hover:bg-surface-hover'
+            }`}
+          >
+            Sign Out
+          </button>
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- **HorizontalScroll**: Content rail arrows always visible in keyboard/D-pad mode (were hover-only, invisible on TV). Removed scroll-snap that trapped D-pad navigation.
- **Player keyboard**: Arrow keys now pass through to spatial nav when a control button is focused, instead of always capturing for seek/volume.
- **Search tabs**: All/Live/Movies/Series filter tabs wrapped in `FocusableTab` with spatial nav context — D-pad navigable with teal focus ring.
- **Profile dropdown**: Extracted `ProfileMenu` component with `useFocusable` on every menu item (Favorites, Watch History, Sign Out) — fully keyboard/D-pad navigable.
- **Volume slider**: Shows on focus (not just mouse hover) via `onFocus`/`onBlur` handlers, accessible on TV remotes.

## Test plan
- [ ] D-pad navigate through content rails on home page — arrows visible, cards focusable
- [ ] Open player, D-pad to play/pause/fullscreen controls — arrow keys don't hijack seek
- [ ] Search page: type query, D-pad to tab buttons (All/Live/Movies/Series) — Enter switches tab
- [ ] D-pad to profile avatar, Enter to open, D-pad through menu items, Enter to select
- [ ] Focus volume button in player — slider appears without mouse hover
- [ ] Mouse mode: all existing behaviors unchanged (hover arrows, click controls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)