### PR TITLE
feat: resume playback + PWA quick wins

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -28,7 +28,7 @@
         fill="none" stroke="url(#brand-gradient)" stroke-width="3" opacity="0.25"/>
 
   <!-- Play triangle (bold, centered, teal-indigo gradient with glow) -->
-  <path d="M208 168 L208 344 L368 256 Z"
+  <path d="M192 168 L192 344 L352 256 Z"
         fill="url(#brand-gradient)" filter="url(#glow)" opacity="0.95"/>
 
   <!-- Subtle keyhole accent at top of shield (vault detail) -->

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -34,5 +34,21 @@
       "type": "image/png",
       "purpose": "maskable"
     }
+  ],
+  "screenshots": [
+    {
+      "src": "/screenshot-wide.png",
+      "sizes": "1280x720",
+      "type": "image/png",
+      "form_factor": "wide",
+      "label": "StreamVault home screen with content rails"
+    },
+    {
+      "src": "/screenshot-narrow.png",
+      "sizes": "390x844",
+      "type": "image/png",
+      "form_factor": "narrow",
+      "label": "StreamVault mobile view"
+    }
   ]
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // Minimal SW to enable PWA install on Samsung TV, Fire Stick, mobile, etc.
 // Does NOT cache aggressively — streaming content should always be live.
 
-const CACHE_NAME = 'streamvault-shell-v1';
+const CACHE_NAME = 'streamvault-shell-v2';
 const SHELL_ASSETS = [
   '/',
   '/manifest.json',
@@ -48,8 +48,10 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // For static assets, try cache first, then network
+  // For static assets, try cache first, then network, then offline fallback
   event.respondWith(
-    caches.match(request).then((cached) => cached || fetch(request))
+    caches.match(request).then((cached) =>
+      cached || fetch(request).catch(() => new Response('', { status: 408, statusText: 'Offline' }))
+    )
   );
 });

--- a/src/features/home/components/ContinueWatching.tsx
+++ b/src/features/home/components/ContinueWatching.tsx
@@ -1,4 +1,5 @@
 import { useWatchHistory } from '../api';
+import { useNavigate } from '@tanstack/react-router';
 import { usePlayerStore } from '@lib/store';
 import { ContentRail } from '@shared/components/ContentRail';
 import { FocusableCard } from '@shared/components/FocusableCard';
@@ -6,6 +7,7 @@ import { FocusableCard } from '@shared/components/FocusableCard';
 export function ContinueWatching() {
   const { data: history, isLoading } = useWatchHistory();
   const playStream = usePlayerStore((s) => s.playStream);
+  const navigate = useNavigate();
 
   const inProgress = (history ?? []).filter((item) => {
     if (item.duration_seconds <= 0) return false;
@@ -16,8 +18,14 @@ export function ContinueWatching() {
   if (!isLoading && inProgress.length === 0) return null;
 
   const handleClick = (item: (typeof inProgress)[0]) => {
-    const type = item.content_type === 'channel' ? 'live' : item.content_type === 'vod' ? 'vod' : 'series';
-    playStream(String(item.content_id), type, item.content_name ?? 'Unknown');
+    if (item.content_type === 'channel') {
+      playStream(String(item.content_id), 'live', item.content_name ?? 'Unknown');
+      navigate({ to: '/live', search: { play: String(item.content_id) } });
+    } else if (item.content_type === 'vod') {
+      navigate({ to: '/vod/$vodId', params: { vodId: String(item.content_id) } });
+    } else if (item.content_type === 'series') {
+      navigate({ to: '/series/$seriesId', params: { seriesId: String(item.content_id) } });
+    }
   };
 
   return (

--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -29,6 +29,7 @@ export function SeriesDetail() {
   const [activeSeason, setActiveSeason] = useState<number | null>(null);
   const [playingEpisodeId, setPlayingEpisodeId] = useState<string | null>(null);
   const [playingEpisodeName, setPlayingEpisodeName] = useState<string>('');
+  const [resumeStartTime, setResumeStartTime] = useState(0);
   const [episodeSort, setEpisodeSort] = useState<EpisodeSortKey>('latest');
   const [episodeSearch, setEpisodeSearch] = useState('');
   const [visibleCount, setVisibleCount] = useState(EPISODES_PER_PAGE);
@@ -154,11 +155,12 @@ export function SeriesDetail() {
   }, [playingEpisodeId, allEpisodes]);
 
   const playEpisode = useCallback(
-    (ep: (typeof allEpisodes)[0]) => {
+    (ep: (typeof allEpisodes)[0], startTime = 0) => {
       setPlayingEpisodeId(String(ep.id));
       setPlayingEpisodeName(
         `${data?.info.name || 'Series'} - S${activeSeason}E${ep.episode_num} - ${ep.title}`
       );
+      setResumeStartTime(startTime);
       window.scrollTo({ top: 0, behavior: 'smooth' });
     },
     [data?.info.name, activeSeason]
@@ -300,6 +302,7 @@ export function SeriesDetail() {
               streamType="series"
               streamId={playingEpisodeId}
               streamName={playingEpisodeName}
+              startTime={resumeStartTime}
               hasNext={currentEpisodeIndex < allEpisodes.length - 1}
               hasPrev={currentEpisodeIndex > 0}
               onNext={playNext}
@@ -316,6 +319,7 @@ export function SeriesDetail() {
               onClick={() => {
                 setPlayingEpisodeId(String(lastWatchedEpisode.content_id));
                 setPlayingEpisodeName(lastWatchedEpisode.content_name || info.name);
+                setResumeStartTime(lastWatchedEpisode.progress_seconds ?? 0);
                 window.scrollTo({ top: 0, behavior: 'smooth' });
               }}
               className="w-full flex items-center gap-4 p-4 rounded-xl bg-gradient-to-r from-teal/10 to-indigo/10 border border-teal/20 hover:border-teal/40 transition-all group"

--- a/src/features/vod/components/MovieDetail.tsx
+++ b/src/features/vod/components/MovieDetail.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useNavigate, useParams } from '@tanstack/react-router';
 import { useVODInfo } from '../api';
+import { useWatchHistory } from '@features/history/api';
 import { StarRating } from '@shared/components/StarRating';
 import { Badge } from '@shared/components/Badge';
 import { Button } from '@shared/components/Button';
@@ -13,7 +14,17 @@ export function MovieDetail() {
   const { vodId } = useParams({ from: '/_authenticated/vod/$vodId' });
   const navigate = useNavigate();
   const { data, isLoading } = useVODInfo(vodId);
+  const { data: watchHistory } = useWatchHistory();
   const [isPlayerOpen, setIsPlayerOpen] = useState(false);
+
+  // Find saved progress for this movie
+  const savedProgress = useMemo(() => {
+    if (!watchHistory) return 0;
+    const entry = watchHistory.find(
+      (h) => h.content_type === 'vod' && String(h.content_id) === vodId
+    );
+    return entry?.progress_seconds ?? 0;
+  }, [watchHistory, vodId]);
 
   if (isLoading) {
     return (
@@ -58,6 +69,7 @@ export function MovieDetail() {
             streamType="vod"
             streamId={vodId}
             streamName={info.name}
+            startTime={savedProgress}
             onClose={() => setIsPlayerOpen(false)}
           />
         </div>
@@ -97,7 +109,7 @@ export function MovieDetail() {
             <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
               <path d="M8 5v14l11-7z" />
             </svg>
-            Play
+            {savedProgress > 0 ? 'Resume' : 'Play'}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **Resume playback**: MovieDetail looks up saved progress from watch history and passes `startTime` to PlayerPage; Play button shows "Resume" when progress exists. SeriesDetail wires `resumeStartTime` through `playEpisode` and resume banner click. ContinueWatching navigates to detail pages (which now handle resume) instead of inline playback.
- **PWA quick wins**: Manifest screenshots for PWABuilder compatibility, SW cache bumped to v2 with offline 408 fallback, icon play triangle optically centered.

## Test plan
- [ ] Open a movie you've partially watched — button should say "Resume" and player should seek to saved position
- [ ] Open a series with watch history — resume banner should start at saved position
- [ ] Click a VOD/series in Continue Watching rail — should navigate to detail page (not inline play)
- [ ] Live channels in Continue Watching still work as before
- [ ] PWA install flow still works on mobile/TV

Generated with Claude Code