### PR TITLE
fix: increase SSH timeout for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
+          timeout: 60s
+          command_timeout: 8m
           script: |
             set -e
             echo "Pulling latest code..."
@@ -51,4 +53,5 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
+          timeout: 60s
           script: docker image prune -f


### PR DESCRIPTION
## Summary
- Increase SSH connection timeout from 30s to 60s (intermittent `dial tcp: i/o timeout` failures)
- Add 8m command timeout for Docker build step
- Applied to both deploy and cleanup steps

## Test plan
- [ ] Merge and verify next deploy succeeds without SSH timeout

Generated with Claude Code