### PR TITLE
fix: complete D-pad navigation for remaining UI elements

### DIFF
--- a/src/features/player/components/MiniPlayer.tsx
+++ b/src/features/player/components/MiniPlayer.tsx
@@ -1,5 +1,24 @@
-import { usePlayerStore } from '@lib/store';
+import { usePlayerStore, useUIStore } from '@lib/store';
 import { PlayerPage } from './PlayerPage';
+import { useFocusable } from '@noriginmedia/norigin-spatial-navigation';
+
+function FocusableCloseButton({ onClick }: { onClick: () => void }) {
+  const inputMode = useUIStore((s) => s.inputMode);
+  const { ref, focused } = useFocusable({ onEnterPress: onClick });
+  const showFocus = focused && inputMode === 'keyboard';
+
+  return (
+    <button
+      ref={ref}
+      onClick={onClick}
+      className={`absolute top-2 right-2 z-10 p-1 bg-obsidian/80 rounded-full text-text-muted hover:text-text-primary transition-colors ${showFocus ? 'ring-2 ring-teal text-text-primary' : ''}`}
+    >
+      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  );
+}
 
 export function MiniPlayer() {
   const currentStreamId = usePlayerStore((s) => s.currentStreamId);
@@ -12,14 +31,7 @@ export function MiniPlayer() {
 
   return (
     <div className="fixed bottom-4 right-4 w-80 z-50 rounded-xl overflow-hidden shadow-2xl border border-border bg-surface">
-      <button
-        onClick={stop}
-        className="absolute top-2 right-2 z-10 p-1 bg-obsidian/80 rounded-full text-text-muted hover:text-text-primary transition-colors"
-      >
-        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-      </button>
+      <FocusableCloseButton onClick={stop} />
       <PlayerPage
         streamType={currentStreamType}
         streamId={currentStreamId}

--- a/src/features/player/components/PlayerControls.tsx
+++ b/src/features/player/components/PlayerControls.tsx
@@ -73,6 +73,45 @@ function FocusableVolumeSlider({ volume, isMuted, onVolumeChange }: {
   );
 }
 
+function FocusableProgressBar({ progressRef, progress, currentTime, duration, onSeek, onSeekTo }: {
+  progressRef: React.RefObject<HTMLDivElement | null>;
+  progress: number;
+  currentTime: number;
+  duration: number;
+  onSeek: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onSeekTo: (time: number) => void;
+}) {
+  const inputMode = useUIStore((s) => s.inputMode);
+  const { ref, focused } = useFocusable({
+    onArrowPress: (direction) => {
+      if (direction === 'left') {
+        onSeekTo(Math.max(0, currentTime - 10));
+        return false;
+      }
+      if (direction === 'right') {
+        onSeekTo(Math.min(duration, currentTime + 10));
+        return false;
+      }
+      return true;
+    },
+  });
+  const showFocus = focused && inputMode === 'keyboard';
+
+  return (
+    <div ref={ref} className="px-4 mb-1">
+      <div
+        ref={progressRef}
+        onClick={onSeek}
+        className={`w-full h-1.5 bg-white/20 cursor-pointer group/progress hover:h-3 transition-all rounded-full ${showFocus ? 'h-3 ring-2 ring-teal/60' : ''}`}
+      >
+        <div className="h-full bg-teal rounded-full relative" style={{ width: `${progress}%` }}>
+          <div className={`absolute right-0 top-1/2 -translate-y-1/2 w-3 h-3 bg-teal rounded-full transition-opacity ${showFocus ? 'opacity-100' : 'opacity-0 group-hover/progress:opacity-100'}`} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 interface PlayerControlsProps {
   playerRef: React.RefObject<VideoPlayerHandle | null>;
   isPlaying: boolean;
@@ -136,17 +175,14 @@ export function PlayerControls({
     >
       {/* Progress bar */}
       {!isLive && duration > 0 && (
-        <div className="px-4 mb-1">
-          <div
-            ref={progressRef}
-            onClick={handleSeek}
-            className="w-full h-1.5 bg-white/20 cursor-pointer group/progress hover:h-3 transition-all rounded-full"
-          >
-            <div className="h-full bg-teal rounded-full relative" style={{ width: `${progress}%` }}>
-              <div className="absolute right-0 top-1/2 -translate-y-1/2 w-3 h-3 bg-teal rounded-full opacity-0 group-hover/progress:opacity-100 transition-opacity" />
-            </div>
-          </div>
-        </div>
+        <FocusableProgressBar
+          progressRef={progressRef}
+          progress={progress}
+          currentTime={currentTime}
+          duration={duration}
+          onSeek={handleSeek}
+          onSeekTo={(t) => playerRef.current?.seek(t)}
+        />
       )}
 
       {/* Controls bar */}

--- a/src/shared/components/ContentCard.tsx
+++ b/src/shared/components/ContentCard.tsx
@@ -16,6 +16,33 @@ interface ContentCardProps {
   focusKey?: string;
 }
 
+function FocusableFavoriteButton({ isFavorite, onToggle }: { isFavorite?: boolean; onToggle: () => void }) {
+  const inputMode = useUIStore((s) => s.inputMode);
+  const { ref, focused } = useFocusable({
+    onEnterPress: () => onToggle(),
+  });
+  const showFocus = focused && inputMode === 'keyboard';
+
+  return (
+    <button
+      ref={ref}
+      onClick={(e) => { e.stopPropagation(); onToggle(); }}
+      className={`absolute top-2 right-2 p-1.5 rounded-full bg-obsidian/60 backdrop-blur-sm hover:bg-obsidian/80 transition-all ${showFocus ? 'ring-2 ring-teal z-10' : ''}`}
+      aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+    >
+      <svg
+        className={`w-4 h-4 ${isFavorite ? 'text-warning fill-warning' : 'text-text-muted'}`}
+        viewBox="0 0 24 24"
+        fill={isFavorite ? 'currentColor' : 'none'}
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+      </svg>
+    </button>
+  );
+}
+
 const aspectClasses = {
   poster: 'aspect-[2/3]',
   landscape: 'aspect-video',
@@ -79,21 +106,7 @@ export function ContentCard({
 
         {/* Favorite star */}
         {onFavoriteToggle && (
-          <button
-            onClick={(e) => { e.stopPropagation(); onFavoriteToggle(); }}
-            className="absolute top-2 right-2 p-1.5 rounded-full bg-obsidian/60 backdrop-blur-sm hover:bg-obsidian/80 transition-all"
-            aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
-          >
-            <svg
-              className={`w-4 h-4 ${isFavorite ? 'text-warning fill-warning' : 'text-text-muted'}`}
-              viewBox="0 0 24 24"
-              fill={isFavorite ? 'currentColor' : 'none'}
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-            </svg>
-          </button>
+          <FocusableFavoriteButton isFavorite={isFavorite} onToggle={onFavoriteToggle} />
         )}
 
         {/* Progress bar */}

--- a/src/shared/components/HorizontalScroll.tsx
+++ b/src/shared/components/HorizontalScroll.tsx
@@ -1,5 +1,29 @@
 import { useRef, useState, useEffect, useCallback, type ReactNode } from 'react';
 import { useUIStore } from '@lib/store';
+import { useFocusable } from '@noriginmedia/norigin-spatial-navigation';
+
+function FocusableScrollArrow({ direction, onClick, arrowOpacity }: {
+  direction: 'left' | 'right';
+  onClick: () => void;
+  arrowOpacity: string;
+}) {
+  const inputMode = useUIStore((s) => s.inputMode);
+  const { ref, focused } = useFocusable({ onEnterPress: onClick });
+  const showFocus = focused && inputMode === 'keyboard';
+
+  return (
+    <button
+      ref={ref}
+      onClick={onClick}
+      className={`absolute ${direction === 'left' ? 'left-0' : 'right-0'} top-1/2 -translate-y-1/2 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-obsidian/80 border border-border-subtle text-text-primary transition-opacity duration-200 hover:bg-surface-raised hover:border-teal/30 ${showFocus ? 'opacity-100 ring-2 ring-teal' : arrowOpacity}`}
+      aria-label={`Scroll ${direction}`}
+    >
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d={direction === 'left' ? 'M15 19l-7-7 7-7' : 'M9 5l7 7-7 7'} />
+      </svg>
+    </button>
+  );
+}
 
 interface HorizontalScrollProps {
   children: ReactNode;
@@ -53,16 +77,7 @@ export function HorizontalScroll({ children, className = '' }: HorizontalScrollP
     <div className={`group/scroll relative ${className}`}>
       {/* Left arrow */}
       {canScrollLeft && (
-        <button
-          onClick={() => scroll('left')}
-          className={`absolute left-0 top-1/2 -translate-y-1/2 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-obsidian/80 border border-border-subtle text-text-primary transition-opacity duration-200 hover:bg-surface-raised hover:border-teal/30 ${arrowOpacity}`}
-          aria-label="Scroll left"
-          tabIndex={-1}
-        >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-          </svg>
-        </button>
+        <FocusableScrollArrow direction="left" onClick={() => scroll('left')} arrowOpacity={arrowOpacity} />
       )}
 
       {/* Scrollable area */}
@@ -75,16 +90,7 @@ export function HorizontalScroll({ children, className = '' }: HorizontalScrollP
 
       {/* Right arrow */}
       {canScrollRight && (
-        <button
-          onClick={() => scroll('right')}
-          className={`absolute right-0 top-1/2 -translate-y-1/2 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-obsidian/80 border border-border-subtle text-text-primary transition-opacity duration-200 hover:bg-surface-raised hover:border-teal/30 ${arrowOpacity}`}
-          aria-label="Scroll right"
-          tabIndex={-1}
-        >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-          </svg>
-        </button>
+        <FocusableScrollArrow direction="right" onClick={() => scroll('right')} arrowOpacity={arrowOpacity} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- **Progress bar**: D-pad left/right seeks ±10s when focused (was mouse-click only)
- **Favorite star**: independently focusable on content cards via D-pad with teal ring
- **MiniPlayer close button**: now focusable with spatial navigation
- **HorizontalScroll arrows**: focusable via D-pad (removed `tabIndex={-1}`, added `useFocusable`)

## Test plan
- [ ] Navigate to progress bar with D-pad, press left/right to seek
- [ ] Navigate to a content card's favorite star with D-pad, press Enter to toggle
- [ ] Open mini player, navigate to close button with D-pad
- [ ] On content rails, navigate to scroll arrows with D-pad

🤖 Generated with [Claude Code](https://claude.com/claude-code)