### PR TITLE
fix: escape input focus trap on D-pad for TV remote

### DIFF
--- a/src/features/auth/components/LoginPage.tsx
+++ b/src/features/auth/components/LoginPage.tsx
@@ -44,6 +44,12 @@ function FocusableInput({ id, type = 'text', placeholder, autoComplete, error, r
           registerRef(el);
           inputRef.current = el;
         }}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+            e.preventDefault();
+            inputRef.current?.blur();
+          }
+        }}
         {...registerRest}
       />
       {error && <p className="text-error text-xs mt-1">{error}</p>}


### PR DESCRIPTION
## Summary
- When typing in username/password fields, arrow keys move the text cursor instead of triggering spatial navigation
- User gets trapped in username field, unable to reach password or sign-in button via D-pad
- Fix: blur input on ArrowDown/ArrowUp so norigin-spatial-navigation regains control

## Test plan
- [ ] On Fire Stick: enter username → press D-pad Down → focus moves to password field
- [ ] On Fire Stick: enter password → press D-pad Down → focus moves to Sign In button
- [ ] On Fire Stick: press D-pad Up from password → focus moves back to username
- [ ] Desktop: mouse/keyboard still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)