### PR TITLE
fix: LRUD navigation bugs, lint errors, TV/Fire Stick UX

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "uk.srinivaskotha.streamvault.twa",
+      "sha256_cert_fingerprints": [
+        "F5:EF:BD:A3:A1:18:C6:B6:50:34:EE:8D:3D:C7:9B:C3:97:C5:0C:6E:D5:41:68:3C:FE:6A:99:3C:BE:09:90:D6"
+      ]
+    }
+  }
+]

--- a/src/features/player/components/PlayerPage.tsx
+++ b/src/features/player/components/PlayerPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useEffect } from 'react';
+import { useRef, useState, useCallback, useEffect, useMemo } from 'react';
 import { useStreamUrl } from '../api';
 import { VideoPlayer, type VideoPlayerHandle, type QualityLevel } from './VideoPlayer';
 import { PlayerControls } from './PlayerControls';
@@ -108,6 +108,19 @@ export function PlayerPage({
     onVolumeDown: handleVolumeDown,
     onClose,
   });
+
+  // Auto-fullscreen in standalone/TV mode (Fire Stick, Samsung TV PWA)
+  const isStandalone = useMemo(() => window.matchMedia('(display-mode: standalone)').matches, []);
+  useEffect(() => {
+    if (!isStandalone || !isPlaying) return;
+    // Small delay to let the video element mount before requesting fullscreen
+    const timer = setTimeout(() => {
+      playerRef.current?.toggleFullscreen();
+    }, 300);
+    return () => clearTimeout(timer);
+    // Only trigger once when playback starts, not on every isPlaying change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isStandalone, streamId]);
 
   // Sync volume to video element
   useEffect(() => {

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -59,8 +59,19 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       },
       getVideo: () => videoRef.current,
       toggleFullscreen: () => {
-        const doc = document as any;
-        const el = containerRef.current as any;
+        const doc = document as Document & {
+          webkitFullscreenElement?: Element;
+          mozFullScreenElement?: Element;
+          msFullscreenElement?: Element;
+          webkitExitFullscreen?: () => void;
+          mozCancelFullScreen?: () => void;
+          msExitFullscreen?: () => void;
+        };
+        const el = containerRef.current as (HTMLDivElement & {
+          webkitRequestFullscreen?: () => void;
+          mozRequestFullScreen?: () => void;
+          msRequestFullscreen?: () => void;
+        }) | null;
         if (!el) return;
 
         const isFullscreen = doc.fullscreenElement || doc.webkitFullscreenElement || doc.mozFullScreenElement || doc.msFullscreenElement;

--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -22,17 +22,33 @@ function formatEpisodeDate(unixTimestamp: string): string {
   return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
 }
 
+interface Episode {
+  id: string;
+  episode_num: number;
+  title: string;
+  container_extension: string;
+  added: string;
+  info: {
+    movie_image: string;
+    duration_secs: number;
+    duration: string;
+    plot: string;
+  };
+  season: number;
+  direct_source: string;
+}
+
 // A wrapper component for episodes in the list to give them individual LRUD hooks cleanly
-function FocusableEpisodeItem({ 
-  ep, 
-  isPlaying, 
-  activeRef, 
-  playEpisode 
-}: { 
-  ep: any; 
-  isPlaying: boolean; 
-  activeRef?: any; 
-  playEpisode: (ep: any) => void;
+function FocusableEpisodeItem({
+  ep,
+  isPlaying,
+  activeRef,
+  playEpisode
+}: {
+  ep: Episode;
+  isPlaying: boolean;
+  activeRef?: React.RefObject<HTMLDivElement | null>;
+  playEpisode: (ep: Episode) => void;
 }) {
   const inputMode = useUIStore((s) => s.inputMode);
   const { ref, isFocused, focusProps } = useLRUD({
@@ -46,8 +62,8 @@ function FocusableEpisodeItem({
 
   return (
     <div
-      ref={(el) => {
-        ref.current = el;
+      ref={(el: HTMLDivElement | null) => {
+        ref(el);
         if (activeRef && isPlaying) activeRef.current = el;
       }}
       {...focusProps}
@@ -192,7 +208,7 @@ export function SeriesDetail() {
       });
     }
     return Array.from(seasonsMap.values()).sort((a, b) => a.season_number - b.season_number);
-  }, [data?.seasons, data?.episodes]);
+  }, [data]);
 
   // All episodes for active season, sorted
   const allEpisodes = useMemo(() => {

--- a/src/features/vod/components/MovieDetail.tsx
+++ b/src/features/vod/components/MovieDetail.tsx
@@ -18,6 +18,7 @@ export function MovieDetail() {
   const { data, isLoading } = useVODInfo(vodId);
   const { data: watchHistory } = useWatchHistory();
   const [isPlayerOpen, setIsPlayerOpen] = useState(false);
+  const inputMode = useUIStore((s) => s.inputMode);
 
   // Find saved progress for this movie
   const savedProgress = useMemo(() => {
@@ -27,20 +28,6 @@ export function MovieDetail() {
     );
     return entry?.progress_seconds ?? 0;
   }, [watchHistory, vodId]);
-
-  if (isLoading) {
-    return (
-      <div className="space-y-4">
-        <Skeleton className="h-64 w-full" />
-        <Skeleton className="h-8 w-1/2" />
-        <Skeleton className="h-4 w-full" />
-        <Skeleton className="h-4 w-3/4" />
-      </div>
-    );
-  }
-
-  if (!data) return null;
-  const { info, movie_data } = data;
 
   const { ref: backRef, isFocused: backFocused, focusProps: backFocusProps } = useLRUD({
     id: `vod-back-${vodId}`,
@@ -60,7 +47,19 @@ export function MovieDetail() {
     onEnter: () => setIsPlayerOpen(true),
   });
 
-  const inputMode = useUIStore((s) => s.inputMode);
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-64 w-full" />
+        <Skeleton className="h-8 w-1/2" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+    );
+  }
+
+  if (!data) return null;
+  const { info, movie_data } = data;
 
   return (
     <div>
@@ -135,10 +134,10 @@ export function MovieDetail() {
               <Badge key={g} variant="teal">{g}</Badge>
             ))}
           </div>
-          <Button 
-            ref={playRef as any}
+          <Button
+            ref={playRef}
             {...playFocusProps}
-            size="lg" 
+            size="lg"
             onClick={() => setIsPlayerOpen(true)}
             className={playFocused && inputMode === 'keyboard' ? 'ring-2 ring-offset-2 ring-offset-obsidian ring-teal' : ''}
           >

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -74,28 +74,32 @@ export const usePlayerStore = create<PlayerState>((set) => ({
   seriesId: null,
   seasonNumber: null,
   episodeIndex: null,
-  playStream: (id, type, name) =>
+  playStream: (id, type, name) => {
+    const isStandalone = window.matchMedia('(display-mode: standalone)').matches;
     set({
       currentStreamId: id,
       currentStreamType: type,
       currentStreamName: name,
       isPlaying: true,
-      isMiniPlayer: true,
+      isMiniPlayer: !isStandalone,
       seriesId: null,
       seasonNumber: null,
       episodeIndex: null,
-    }),
-  playSeries: (id, type, name, seriesId, season, epIndex) =>
+    });
+  },
+  playSeries: (id, type, name, seriesId, season, epIndex) => {
+    const isStandalone = window.matchMedia('(display-mode: standalone)').matches;
     set({
       currentStreamId: id,
       currentStreamType: type,
       currentStreamName: name,
       isPlaying: true,
-      isMiniPlayer: true,
+      isMiniPlayer: !isStandalone,
       seriesId,
       seasonNumber: season,
       episodeIndex: epIndex,
-    }),
+    });
+  },
   stop: () =>
     set({
       currentStreamId: null,

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 import { TopNav } from '@shared/components/TopNav';
-import { LRUDProvider } from '@shared/providers/LRUDProvider';
 import { useAuthStore } from '@lib/store';
 import { useAuthCheck } from '@features/auth/hooks/useAuth';
 import { useBackNavigation } from '@shared/hooks/useBackNavigation';
@@ -27,13 +26,11 @@ function AuthenticatedLayout() {
   useBackNavigation();
 
   return (
-    <LRUDProvider>
-      <div className="min-h-screen bg-obsidian">
-        <TopNav />
-        <main className="min-h-screen pt-16 overflow-y-auto">
-          <Outlet />
-        </main>
-      </div>
-    </LRUDProvider>
+    <div className="min-h-screen bg-obsidian">
+      <TopNav />
+      <main className="min-h-screen pt-16 overflow-y-auto">
+        <Outlet />
+      </main>
+    </div>
   );
 }

--- a/src/shared/hooks/useLRUD.ts
+++ b/src/shared/hooks/useLRUD.ts
@@ -13,45 +13,49 @@ interface UseLRUDOptions extends Omit<NodeConfig, 'id'> {
 export function useLRUD({ id, onEnter, onFocus, onBlur, parent = 'root', ...config }: UseLRUDOptions) {
   const { lrud } = useLRUDContext();
   const [isFocused, setIsFocused] = useState(false);
-  const ref = useRef<any>(null);
+  const elementRef = useRef<HTMLElement | null>(null);
+
+  // Callback ref compatible with any HTML element type
+  const ref = useCallback((node: HTMLElement | null) => {
+    elementRef.current = node;
+  }, []);
+
+  // Use refs for callbacks to avoid re-registration on every render
+  const onEnterRef = useRef(onEnter);
+  const onFocusRef = useRef(onFocus);
+  const onBlurRef = useRef(onBlur);
+  onEnterRef.current = onEnter;
+  onFocusRef.current = onFocus;
+  onBlurRef.current = onBlur;
 
   useEffect(() => {
-    // Register the node in the LRUD tree
+    // Register the node in the LRUD tree with parent
     lrud.registerNode(id, {
+      parent,
       ...config,
       onFocus: () => {
         setIsFocused(true);
-        if (onFocus) onFocus();
-        
+        onFocusRef.current?.();
+
         // Auto-scroll the DOM node into view when focused by the keyboard
-        if (ref.current && typeof ref.current.scrollIntoView === 'function') {
-          ref.current.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+        if (elementRef.current && typeof elementRef.current.scrollIntoView === 'function') {
+          elementRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
         }
       },
       onBlur: () => {
         setIsFocused(false);
-        if (onBlur) onBlur();
+        onBlurRef.current?.();
       },
       onSelect: () => {
-        if (onEnter) onEnter();
+        onEnterRef.current?.();
       }
     });
-
-    // If it has a parent other than root, we need to ensure the parent exists or register it to the parent.
-    // However, the Lrud API registers nodes at the top level and handles relationships via parent ids internally or structurally.
-    // The current version of @bam.tech/lrud registers nodes via lrud.registerNode(id, config) ignoring a parent tree structure explicitly at registration unless it's given the parent ID in its config.
-    // To support parent references we need to assign it to the parent in the tree if parent !== 'root'.
-    if (parent && parent !== 'root') {
-      try { lrud.assignFocus(parent); } catch (e) {} // ensure parent is known
-      lrud.registerNode(id, { isFocusable: config.isFocusable ?? true });
-      // NOTE: actually, lrud.registerNode only accepts 1-2 args: id, nodeConfig. Since `parent` is a property on nodeConfig for older versions, we should just pass it in nodeConfig if valid, or handle structural nodes. We'll simplify and trust lrud's state for this app's flat/simple spatial layout to rely more on DOM ordering and proximity handling.
-    }
 
     return () => {
       // Unregister the node when the component unmounts
       try {
         lrud.unregisterNode(id);
-      } catch (e) {
+      } catch {
         // Node might already be gone
       }
     };
@@ -61,7 +65,7 @@ export function useLRUD({ id, onEnter, onFocus, onBlur, parent = 'root', ...conf
   const handleMouseEnter = useCallback(() => {
     try {
       lrud.assignFocus(id);
-    } catch (e) {
+    } catch {
       // Ignore if node is not focusable or tree isn't ready
     }
   }, [id, lrud]);
@@ -69,8 +73,8 @@ export function useLRUD({ id, onEnter, onFocus, onBlur, parent = 'root', ...conf
   const setFocus = useCallback(() => {
     try {
       lrud.assignFocus(id);
-    } catch (e) {
-      console.warn(`Could not focus LRUD node ${id}`, e);
+    } catch {
+      console.warn(`Could not focus LRUD node ${id}`);
     }
   }, [id, lrud]);
 
@@ -81,7 +85,7 @@ export function useLRUD({ id, onEnter, onFocus, onBlur, parent = 'root', ...conf
     focusProps: {
       onMouseEnter: handleMouseEnter,
       // For accessibility, still use standard focus handlers if the element is naturally focusable
-      onFocus: handleMouseEnter, 
+      onFocus: handleMouseEnter,
     }
   };
 }

--- a/src/shared/providers/LRUDProvider.tsx
+++ b/src/shared/providers/LRUDProvider.tsx
@@ -36,6 +36,10 @@ export function LRUDProvider({ children }: LRUDProviderProps) {
 
     // Handle keydown events to drive LRUD
     function handleKeyDown(e: KeyboardEvent) {
+      // Don't intercept keys when user is typing in an input
+      const tag = (document.activeElement as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
       const isNavKey = [
         'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
         'Up', 'Down', 'Left', 'Right',


### PR DESCRIPTION
## Summary
- **Fix LRUD parent-child registration** — `parent` was destructured out but never passed to `registerNode()`, making all nodes flat under root. D-pad navigation now follows proper hierarchical focus tree.
- **Remove duplicate LRUDProvider** from `_authenticated.tsx` — was already wrapped in `main.tsx`, causing duplicate keydown listeners
- **Fix 15 ESLint errors** — conditional hooks in MovieDetail, `any` types in SeriesDetail/VideoPlayer/useLRUD, unused catch variables
- **Skip LRUD key handling on inputs** — arrow keys were intercepted even when typing in text fields
- **Auto-fullscreen in standalone/TV mode** — Fire Stick & Samsung TV PWA now auto-fullscreen when Play is pressed
- **Add `.well-known/assetlinks.json`** — TWA digital asset links verification to remove browser chrome on Fire Stick APK
- **useRef for LRUD callbacks** — prevents unnecessary re-registration on every render

## Test plan
- [ ] `npm run lint` — 0 errors (1 intentional warning)
- [ ] `npm run build` — succeeds
- [ ] CI/CD passes (lint + typecheck)
- [ ] Test D-pad navigation in browser with arrow keys on localhost
- [ ] Test login form — arrow keys should move cursor in inputs, not trigger LRUD
- [ ] Deploy and test on Fire Stick APK — verify no browser chrome
- [ ] Verify Play button auto-fullscreens on Fire Stick

🤖 Generated with [Claude Code](https://claude.com/claude-code)