### PR TITLE
fix: persist auth across app restarts

### DIFF
--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -12,8 +12,8 @@ export function useAuthCheck() {
     queryFn: async () => {
       const ok = await checkAuth();
       if (ok) {
-        // Recover username from sessionStorage (set during login), fallback to 'user'
-        const savedUsername = sessionStorage.getItem('sv_user') || 'user';
+        // Recover username from localStorage (set during login), fallback to 'user'
+        const savedUsername = localStorage.getItem('sv_user') || 'user';
         setAuth(savedUsername);
       } else {
         clearAuth();

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -8,16 +8,16 @@ interface AuthState {
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
-  isAuthenticated: sessionStorage.getItem('sv_auth') === '1',
-  username: sessionStorage.getItem('sv_user'),
+  isAuthenticated: localStorage.getItem('sv_auth') === '1',
+  username: localStorage.getItem('sv_user'),
   setAuth: (username) => {
-    sessionStorage.setItem('sv_auth', '1');
-    sessionStorage.setItem('sv_user', username);
+    localStorage.setItem('sv_auth', '1');
+    localStorage.setItem('sv_user', username);
     set({ isAuthenticated: true, username });
   },
   clearAuth: () => {
-    sessionStorage.removeItem('sv_auth');
-    sessionStorage.removeItem('sv_user');
+    localStorage.removeItem('sv_auth');
+    localStorage.removeItem('sv_user');
     set({ isAuthenticated: false, username: null });
   },
 }));

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -3,12 +3,19 @@ import { TopNav } from '@shared/components/TopNav';
 import { useAuthStore } from '@lib/store';
 import { useAuthCheck } from '@features/auth/hooks/useAuth';
 import { useBackNavigation } from '@shared/hooks/useBackNavigation';
-import { autoLogin } from '@features/auth/api';
+import { autoLogin, checkAuth } from '@features/auth/api';
 
 export const Route = createFileRoute('/_authenticated')({
   beforeLoad: async () => {
     const { isAuthenticated, setAuth } = useAuthStore.getState();
     if (!isAuthenticated) {
+      // Try silent cookie-based auth check (httpOnly refresh token may still be valid)
+      const cookieValid = await checkAuth();
+      if (cookieValid) {
+        const savedUsername = localStorage.getItem('sv_user') || 'user';
+        setAuth(savedUsername);
+        return;
+      }
       // Try IP-based auto-login (LAN bypass)
       const result = await autoLogin();
       if (result) {


### PR DESCRIPTION
## Summary
- Switch auth state from `sessionStorage` to `localStorage` so login persists when TWA/browser closes on Fire Stick
- Add silent cookie-based auth check in route guard — if localStorage is cleared but 90-day httpOnly refresh token is still valid, user stays logged in
- Fix `useAuthCheck` hook to read username from `localStorage` instead of `sessionStorage`

## Root Cause
`sessionStorage` is scoped to a browser tab/session. When Fire Stick TWA closes, the session ends and `sv_auth` flag is wiped. On reopen, the app redirects to login even though the httpOnly cookie (90-day refresh token) is still valid.

## Test plan
- [ ] Login on desktop → close tab → reopen → should stay logged in
- [ ] Login on Fire Stick → close app → reopen → should stay logged in
- [ ] Logout → verify localStorage cleared → redirected to login
- [ ] Clear localStorage manually → app still recovers via cookie check

🤖 Generated with [Claude Code](https://claude.com/claude-code)