### PR TITLE
fix: LRUD duplicate node IDs crash + stale SW cache

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // Minimal SW to enable PWA install on Samsung TV, Fire Stick, mobile, etc.
 // Does NOT cache aggressively — streaming content should always be live.
 
-const CACHE_NAME = 'streamvault-shell-v2';
+const CACHE_NAME = 'streamvault-shell-v3';
 const SHELL_ASSETS = [
   '/',
   '/manifest.json',

--- a/src/shared/components/HorizontalScroll.tsx
+++ b/src/shared/components/HorizontalScroll.tsx
@@ -1,15 +1,16 @@
-import { useRef, useState, useEffect, useCallback, type ReactNode } from 'react';
+import { useRef, useState, useEffect, useCallback, useId, type ReactNode } from 'react';
 import { useUIStore } from '@lib/store';
 import { useLRUD } from '@shared/hooks/useLRUD';
 
-function FocusableScrollArrow({ direction, onClick, arrowOpacity }: {
+function FocusableScrollArrow({ direction, onClick, arrowOpacity, instanceId }: {
   direction: 'left' | 'right';
   onClick: () => void;
   arrowOpacity: string;
+  instanceId: string;
 }) {
   const inputMode = useUIStore((s) => s.inputMode);
   const { ref, isFocused, focusProps } = useLRUD({
-    id: `scroll-arrow-${direction}`,
+    id: `scroll-arrow-${direction}-${instanceId}`,
     parent: 'root',
     onEnter: onClick,
   });
@@ -36,6 +37,7 @@ interface HorizontalScrollProps {
 }
 
 export function HorizontalScroll({ children, className = '' }: HorizontalScrollProps) {
+  const instanceId = useId();
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
@@ -82,7 +84,7 @@ export function HorizontalScroll({ children, className = '' }: HorizontalScrollP
     <div className={`group/scroll relative ${className}`}>
       {/* Left arrow */}
       {canScrollLeft && (
-        <FocusableScrollArrow direction="left" onClick={() => scroll('left')} arrowOpacity={arrowOpacity} />
+        <FocusableScrollArrow direction="left" onClick={() => scroll('left')} arrowOpacity={arrowOpacity} instanceId={instanceId} />
       )}
 
       {/* Scrollable area */}
@@ -95,7 +97,7 @@ export function HorizontalScroll({ children, className = '' }: HorizontalScrollP
 
       {/* Right arrow */}
       {canScrollRight && (
-        <FocusableScrollArrow direction="right" onClick={() => scroll('right')} arrowOpacity={arrowOpacity} />
+        <FocusableScrollArrow direction="right" onClick={() => scroll('right')} arrowOpacity={arrowOpacity} instanceId={instanceId} />
       )}
     </div>
   );

--- a/src/shared/hooks/useLRUD.ts
+++ b/src/shared/hooks/useLRUD.ts
@@ -29,6 +29,9 @@ export function useLRUD({ id, onEnter, onFocus, onBlur, parent = 'root', ...conf
   onBlurRef.current = onBlur;
 
   useEffect(() => {
+    // Unregister first in case the node already exists (e.g. HMR, re-mount)
+    try { lrud.unregisterNode(id); } catch { /* not registered yet */ }
+
     // Register the node in the LRUD tree with parent
     lrud.registerNode(id, {
       parent,


### PR DESCRIPTION
## Summary
- Fix crash: `HorizontalScroll` used static LRUD IDs (`scroll-arrow-left/right`) causing "already registered" error when multiple content rails render on the home page
- Add `useId()` for unique per-instance scroll arrow IDs
- Add defensive unregister-before-register in `useLRUD` hook to prevent crashes on re-mount/HMR
- Bump service worker cache to v3 to clear stale `main.css` references from old builds

## Root Cause
Multiple `HorizontalScroll` instances (Live, VOD, Series rails) all registered `scroll-arrow-right` with the same ID. LRUD throws on duplicate registration, crashing the entire app.

## Test plan
- [ ] Home page loads without "already registered" error
- [ ] Scroll arrows work on content rails
- [ ] Hard refresh clears stale SW cache (no more blocked:csp on main.css)

🤖 Generated with [Claude Code](https://claude.com/claude-code)