### PR TITLE
fix: guard against empty provider response crash

### DIFF
--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -373,7 +373,16 @@ export function SeriesDetail() {
     );
   }
 
-  if (!data) return null;
+  if (!data || !data.info || Array.isArray(data.info) || !data.info.name) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-text-muted">Content unavailable. The provider may be temporarily down.</p>
+        <button onClick={() => navigate({ to: '/series' })} className="mt-4 px-4 py-2 bg-teal/15 text-teal rounded-lg text-sm hover:bg-teal/25 transition-colors">
+          Back to Series
+        </button>
+      </div>
+    );
+  }
   const { info, seasons } = data;
 
   return (

--- a/src/features/vod/components/MovieDetail.tsx
+++ b/src/features/vod/components/MovieDetail.tsx
@@ -58,7 +58,16 @@ export function MovieDetail() {
     );
   }
 
-  if (!data) return null;
+  if (!data || !data.info || Array.isArray(data.info) || !data.info.name) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-text-muted">Content unavailable. The provider may be temporarily down.</p>
+        <button onClick={() => navigate({ to: '/vod' })} className="mt-4 px-4 py-2 bg-teal/15 text-teal rounded-lg text-sm hover:bg-teal/25 transition-colors">
+          Back to Movies
+        </button>
+      </div>
+    );
+  }
   const { info, movie_data } = data;
 
   return (


### PR DESCRIPTION
## Summary
- Guard MovieDetail and SeriesDetail against empty/array `info` from Xtream provider
- When upstream returns 404, API returns `{ info: [] }` instead of `{ info: { name: ... } }`
- Shows friendly "Content unavailable" message instead of crashing

## Test plan
- [ ] Navigate to a VOD/series when provider is down → shows fallback message, no crash
- [ ] Navigate when provider is up → works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)