### PR TITLE
fix: comprehensive LRUD D-pad navigation for Fire Stick

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -53,8 +53,9 @@ server {
         types { application/manifest+json json; }
     }
 
-    # SPA routing
+    # SPA routing — index.html must not be cached (JS/CSS have content hashes)
     location / {
+        add_header Cache-Control "no-cache" always;
         try_files $uri $uri/ /index.html;
     }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // Minimal SW to enable PWA install on Samsung TV, Fire Stick, mobile, etc.
 // Does NOT cache aggressively — streaming content should always be live.
 
-const CACHE_NAME = 'streamvault-shell-v3';
+const CACHE_NAME = 'streamvault-shell-v4';
 const SHELL_ASSETS = [
   '/',
   '/manifest.json',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { queryClient } from '@lib/queryClient';
@@ -12,9 +13,18 @@ declare module '@tanstack/react-router' {
 }
 
 export function App() {
+  const appRef = useRef<HTMLDivElement>(null);
+
+  // Android TV WebViews need a focused DOM element to dispatch D-pad events
+  useEffect(() => {
+    appRef.current?.focus();
+  }, []);
+
   return (
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
+    <div ref={appRef} tabIndex={-1} style={{ outline: 'none' }}>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </div>
   );
 }

--- a/src/shared/components/TopNav.tsx
+++ b/src/shared/components/TopNav.tsx
@@ -15,6 +15,14 @@ export function TopNav() {
   const [scrolled, setScrolled] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
 
+  // Register the top-nav LRUD container so children (hamburger, nav-items, profile-btn) have a parent
+  const { ref: topNavRef } = useLRUD({
+    id: 'top-nav',
+    parent: 'root',
+    orientation: 'horizontal',
+    isFocusable: false,
+  });
+
   // Detect languages from categories
   const { data: liveCategories } = useLiveCategories();
   const { data: vodCategories } = useVODCategories();
@@ -67,6 +75,7 @@ export function TopNav() {
 
   return (
     <header
+      ref={topNavRef}
       className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
         scrolled || mobileMenuOpen
           ? 'bg-obsidian/90 backdrop-blur-xl border-b border-border-subtle shadow-lg'
@@ -244,6 +253,14 @@ function ProfileMenu({
   const navigate = useNavigate();
   const inputMode = useUIStore((s) => s.inputMode);
 
+  // Register the profile-menu LRUD container so dropdown children have a parent
+  const { ref: menuRef } = useLRUD({
+    id: 'profile-menu',
+    parent: 'top-nav',
+    orientation: 'vertical',
+    isFocusable: false,
+  });
+
   const { ref: profileBtnRef, isFocused: profileFocused } = useLRUD({
     id: 'profile-btn',
     parent: 'top-nav',
@@ -288,7 +305,7 @@ function ProfileMenu({
       </button>
 
       {profileOpen && (
-        <div role="menu" className="absolute right-0 top-full mt-2 w-48 py-2 bg-surface-raised border border-border rounded-lg shadow-xl z-[60]">
+        <div ref={menuRef} role="menu" className="absolute right-0 top-full mt-2 w-48 py-2 bg-surface-raised border border-border rounded-lg shadow-xl z-[60]">
           <Link
             ref={favRef}
             to="/favorites"


### PR DESCRIPTION
## Summary
Deep investigation into why Fire Stick D-pad navigation doesn't work. Found 4 root causes:

- **App root not focusable**: Android TV WebViews need a focused DOM element to dispatch D-pad events to JavaScript. Without it, `window.addEventListener('keydown')` never fires. Added `tabIndex={-1}` + auto-focus on mount.
- **Missing LRUD parent nodes**: `top-nav` and `profile-menu` were referenced by ~10 child nodes but never registered. `@bam.tech/lrud` silently drops nodes whose parent doesn't exist — they just vanish from the tree. All nav items, hamburger menu, and profile dropdown were invisible to LRUD.
- **Stale service worker cache**: Bumped from v3 to v4 to force old cached index.html replacement.
- **index.html caching**: Added `no-cache` header to SPA routing in nginx.conf so browsers always get fresh HTML (JS/CSS already have content hashes).

## Test plan
- [ ] Fire Stick: D-pad up/down/left/right navigates between content cards
- [ ] Fire Stick: D-pad navigates through top nav items
- [ ] Fire Stick: Enter/Select activates focused element  
- [ ] Fire Stick: Force stop app → relaunch → D-pad works immediately
- [ ] Desktop: Arrow key navigation still works
- [ ] Mobile: Touch interactions unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)