### PR TITLE
fix: aggressive focus recovery for Fire Stick TV remote

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // Minimal SW to enable PWA install on Samsung TV, Fire Stick, mobile, etc.
 // Does NOT cache aggressively — streaming content should always be live.
 
-const CACHE_NAME = 'streamvault-shell-v4';
+const CACHE_NAME = 'streamvault-shell-v5';
 const SHELL_ASSETS = [
   '/',
   '/manifest.json',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useMemo } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, createRouter } from '@tanstack/react-router';
 import { queryClient } from '@lib/queryClient';
@@ -14,14 +14,45 @@ declare module '@tanstack/react-router' {
 
 export function App() {
   const appRef = useRef<HTMLDivElement>(null);
+  const isStandalone = useMemo(() => window.matchMedia('(display-mode: standalone)').matches, []);
 
-  // Android TV WebViews need a focused DOM element to dispatch D-pad events
   useEffect(() => {
-    appRef.current?.focus();
-  }, []);
+    // In standalone/TV mode (Fire Stick, TWA), ensure the root element has focus
+    // so the Android WebView dispatches D-pad key events to JavaScript.
+    // In browser mode, skip this — mouse/touch interactions work without it.
+    if (!isStandalone) return;
+
+    appRef.current?.focus({ preventScroll: true });
+
+    // Re-focus when focus completely escapes the app (overlay dismiss, etc.)
+    const handleFocusOut = (e: FocusEvent) => {
+      if (e.relatedTarget && appRef.current?.contains(e.relatedTarget as Node)) return;
+      requestAnimationFrame(() => {
+        const active = document.activeElement;
+        if (!active || active === document.body || active === document.documentElement) {
+          appRef.current?.focus({ preventScroll: true });
+        }
+      });
+    };
+
+    // Re-focus when app returns from background (Fire Stick home → back to app)
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        setTimeout(() => appRef.current?.focus({ preventScroll: true }), 100);
+      }
+    };
+
+    document.addEventListener('focusout', handleFocusOut);
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      document.removeEventListener('focusout', handleFocusOut);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [isStandalone]);
 
   return (
-    <div ref={appRef} tabIndex={-1} style={{ outline: 'none' }}>
+    <div ref={appRef} tabIndex={isStandalone ? -1 : undefined} style={{ outline: 'none' }}>
       <QueryClientProvider client={queryClient}>
         <RouterProvider router={router} />
       </QueryClientProvider>

--- a/src/features/player/components/PlayerControls.tsx
+++ b/src/features/player/components/PlayerControls.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useMemo } from 'react';
 import type { QualityLevel, VideoPlayerHandle } from './VideoPlayer';
+import type React from 'react';
 import { formatDuration } from '@shared/utils/formatDuration';
 import { useUIStore, usePlayerStore } from '@lib/store';
 import { useLRUD } from '@shared/hooks/useLRUD';
@@ -74,10 +75,13 @@ function FocusableVolumeSlider({ volume, isMuted, onVolumeChange }: {
   );
 }
 
-function FocusableProgressBar({ progressRef, progress, onSeek }: {
+function FocusableProgressBar({ progressRef, progress, onSeek, playerRef, duration, isLive }: {
   progressRef: React.RefObject<HTMLDivElement | null>;
   progress: number;
   onSeek: (e: React.MouseEvent<HTMLDivElement>) => void;
+  playerRef: React.RefObject<VideoPlayerHandle | null>;
+  duration: number;
+  isLive: boolean;
 }) {
   const inputMode = useUIStore((s) => s.inputMode);
   const { ref, isFocused, focusProps } = useLRUD({
@@ -85,17 +89,25 @@ function FocusableProgressBar({ progressRef, progress, onSeek }: {
     parent: 'player-controls',
   });
 
-  // Note: D-pad left/right seek while focused on progress bar is typically
-  // handled globally via usePlayerKeyboard rather than at the element level in LRUD.
-  
   const showFocus = isFocused && inputMode === 'keyboard';
+
+  const handleTouchSeek = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
+    if (!progressRef.current || isLive || !duration) return;
+    const rect = progressRef.current.getBoundingClientRect();
+    const touch = e.touches[0] || e.changedTouches[0];
+    if (!touch) return;
+    const pct = Math.max(0, Math.min(1, (touch.clientX - rect.left) / rect.width));
+    playerRef.current?.seek(pct * duration);
+  }, [progressRef, playerRef, duration, isLive]);
 
   return (
     <div ref={ref} {...focusProps} className="px-4 mb-1">
       <div
         ref={progressRef}
         onClick={onSeek}
-        className={`w-full h-1.5 bg-white/20 cursor-pointer group/progress hover:h-3 transition-all rounded-full ${showFocus ? 'h-3 ring-2 ring-teal/60' : ''}`}
+        onTouchStart={handleTouchSeek}
+        onTouchMove={handleTouchSeek}
+        className={`w-full h-1.5 bg-white/20 cursor-pointer group/progress hover:h-3 transition-all rounded-full touch-none ${showFocus ? 'h-3 ring-2 ring-teal/60' : ''}`}
       >
         <div className="h-full bg-teal rounded-full relative" style={{ width: `${progress}%` }}>
           <div className={`absolute right-0 top-1/2 -translate-y-1/2 w-3 h-3 bg-teal rounded-full transition-opacity ${showFocus ? 'opacity-100' : 'opacity-0 group-hover/progress:opacity-100'}`} />
@@ -173,6 +185,9 @@ export function PlayerControls({
           progressRef={progressRef}
           progress={progress}
           onSeek={handleSeek}
+          playerRef={playerRef}
+          duration={duration}
+          isLive={isLive}
         />
       )}
 

--- a/src/features/player/components/PlayerPage.tsx
+++ b/src/features/player/components/PlayerPage.tsx
@@ -176,6 +176,13 @@ export function PlayerPage({
       className="relative aspect-video bg-black rounded-xl overflow-hidden focus:outline-none"
       onMouseMove={showControls}
       onMouseLeave={() => isPlaying && setControlsVisible(false)}
+      onClick={() => {
+        if (controlsVisible) {
+          setControlsVisible(false);
+        } else {
+          showControls();
+        }
+      }}
     >
       <VideoPlayer
         ref={playerRef}

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -67,12 +67,6 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           mozCancelFullScreen?: () => void;
           msExitFullscreen?: () => void;
         };
-        const el = containerRef.current as (HTMLDivElement & {
-          webkitRequestFullscreen?: () => void;
-          mozRequestFullScreen?: () => void;
-          msRequestFullscreen?: () => void;
-        }) | null;
-        if (!el) return;
 
         const isFullscreen = doc.fullscreenElement || doc.webkitFullscreenElement || doc.mozFullScreenElement || doc.msFullscreenElement;
 
@@ -81,12 +75,25 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           else if (doc.webkitExitFullscreen) doc.webkitExitFullscreen();
           else if (doc.mozCancelFullScreen) doc.mozCancelFullScreen();
           else if (doc.msExitFullscreen) doc.msExitFullscreen();
-        } else {
-          if (el.requestFullscreen) el.requestFullscreen();
-          else if (el.webkitRequestFullscreen) el.webkitRequestFullscreen();
-          else if (el.mozRequestFullScreen) el.mozRequestFullScreen();
-          else if (el.msRequestFullscreen) el.msRequestFullscreen();
+          return;
         }
+
+        // Try container fullscreen first (shows controls overlay), fall back to video element (iOS)
+        const el = containerRef.current as (HTMLDivElement & {
+          webkitRequestFullscreen?: () => void;
+          mozRequestFullScreen?: () => void;
+          msRequestFullscreen?: () => void;
+        }) | null;
+
+        const video = videoRef.current as (HTMLVideoElement & {
+          webkitEnterFullscreen?: () => void;
+        }) | null;
+
+        if (el?.requestFullscreen) el.requestFullscreen().catch(() => { video?.webkitEnterFullscreen?.(); });
+        else if (el?.webkitRequestFullscreen) el.webkitRequestFullscreen();
+        else if (el?.mozRequestFullScreen) el.mozRequestFullScreen();
+        else if (el?.msRequestFullscreen) el.msRequestFullscreen();
+        else if (video?.webkitEnterFullscreen) video.webkitEnterFullscreen(); // iOS Safari fallback
       },
       togglePiP: async () => {
         const video = videoRef.current;

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -20,6 +20,16 @@ function FullscreenPlayer() {
 
   return (
     <div className="fixed inset-0 z-50 bg-black">
+      {/* Close button — always visible */}
+      <button
+        onClick={stop}
+        className="absolute top-4 right-4 z-[60] p-2 bg-obsidian/70 rounded-full text-white/80 hover:text-white hover:bg-obsidian/90 transition-colors"
+        aria-label="Close player"
+      >
+        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
       <PlayerPage
         streamType={currentStreamType}
         streamId={currentStreamId}

--- a/src/shared/providers/LRUDProvider.tsx
+++ b/src/shared/providers/LRUDProvider.tsx
@@ -34,18 +34,21 @@ export function LRUDProvider({ children }: LRUDProviderProps) {
       rootRegistered.current = true;
     }
 
-    // Handle keydown events to drive LRUD
+    // Handle keydown events to drive LRUD.
+    // Use capture phase so we intercept before any child element can swallow the event.
     function handleKeyDown(e: KeyboardEvent) {
-      // Don't intercept keys when user is typing in an input
+      // Don't intercept keys when user is typing in an input — EXCEPT arrow
+      // keys which should escape the input and navigate via LRUD
       const tag = (document.activeElement as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      const isInInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+      const isArrow = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
+                        'Up', 'Down', 'Left', 'Right'].includes(e.key);
 
-      const isNavKey = [
-        'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
-        'Up', 'Down', 'Left', 'Right',
-        'Enter', 'Escape', 'Backspace'
-      ].includes(e.key);
-      
+      // Let non-arrow keys through to inputs normally
+      if (isInInput && !isArrow) return;
+
+      const isNavKey = isArrow || ['Enter', 'Escape', 'Backspace'].includes(e.key);
+
       if (isNavKey) {
         setInputMode('keyboard');
 
@@ -54,6 +57,11 @@ export function LRUDProvider({ children }: LRUDProviderProps) {
         if (!lrud.currentFocusNode) {
           try { lrud.assignFocus('root'); } catch { /* no focusable nodes yet */ }
         }
+      }
+
+      // If in an input and arrow pressed, blur the input first so LRUD takes over
+      if (isInInput && isArrow) {
+        (document.activeElement as HTMLElement)?.blur();
       }
 
       // Map keys to LRUD directions
@@ -89,11 +97,12 @@ export function LRUDProvider({ children }: LRUDProviderProps) {
       setInputMode('mouse');
     }
 
-    window.addEventListener('keydown', handleKeyDown);
+    // Use capture: true to intercept before child elements can swallow events
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
     window.addEventListener('mousemove', handleMouseMove, { passive: true });
 
     return () => {
-      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keydown', handleKeyDown, { capture: true });
       window.removeEventListener('mousemove', handleMouseMove);
     };
   }, [setInputMode]);


### PR DESCRIPTION
## Summary
- **Root cause**: Android TV WebView doesn't dispatch D-pad key events to JavaScript unless a DOM element has focus. Previous fix only focused once on mount — focus gets lost after route changes/overlay dismissals, making the remote completely dead (except back/exit handled by Android OS)
- **App.tsx**: Continuous focus recovery via `focusout` + `visibilitychange` listeners (standalone/TWA mode only — no-op in browser)
- **LRUDProvider**: Capture-phase `keydown` to intercept before child elements swallow events; arrow keys in inputs now blur + navigate via LRUD instead of being trapped
- **Player UX**: Touch seek on progress bar, click toggles controls, iOS fullscreen fallback (`webkitEnterFullscreen`), close button on fullscreen overlay
- **SW cache bump** v4→v5 to force update on Fire Stick

## Test plan
- [ ] Fire Stick: D-pad up/down/left/right navigates between focusable elements on login page
- [ ] Fire Stick: Enter/Select button activates focused element
- [ ] Fire Stick: After navigating away and back, remote still works (focus recovery)
- [ ] Fire Stick: After returning from home screen, remote still works (visibility change)
- [ ] Browser: No regression — mouse/keyboard navigation works normally
- [ ] Player: Touch seek works on progress bar (mobile)
- [ ] Player: Click toggles controls overlay visibility
- [ ] Player: Fullscreen close button visible and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)