### PR TITLE
fix: LRUD nodes not focusable + dual event dispatch for Fire TV D-pad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,12 @@ Thumbs.db
 # Logs
 *.log
 npm-debug.log*
+
+# Fire TV build artifacts
+*.apk
+*.idsig
+*.jks
+fire-tv/.gradle/
+fire-tv/build/
+fire-tv/app/build/
+fire-tv/gradle/wrapper/gradle-wrapper.jar

--- a/fire-tv/app/src/main/java/uk/srinivaskotha/streamvault/MainActivity.kt
+++ b/fire-tv/app/src/main/java/uk/srinivaskotha/streamvault/MainActivity.kt
@@ -130,8 +130,9 @@ class MainActivity : Activity() {
 
             if (eventType != null) {
                 // Inject a synthetic KeyboardEvent directly into JavaScript.
-                // Only dispatch on document (not both document AND window)
-                // to avoid double-firing the LRUD handler.
+                // Dispatch to both window and document so the handler fires
+                // regardless of which cached frontend version is loaded.
+                // JS-side dedup (50ms window) prevents double-firing.
                 val js = """
                     (function() {
                         var e = new KeyboardEvent('$eventType', {
@@ -142,7 +143,18 @@ class MainActivity : Activity() {
                             bubbles: true,
                             cancelable: true
                         });
-                        document.dispatchEvent(e);
+                        // Dispatch to BOTH targets — old cached frontend may listen on
+                        // window, new frontend listens on document. Dedup handled in JS.
+                        window.dispatchEvent(e);
+                        var e2 = new KeyboardEvent('$eventType', {
+                            key: '$key',
+                            code: '$code',
+                            keyCode: $keyCode,
+                            which: $keyCode,
+                            bubbles: true,
+                            cancelable: true
+                        });
+                        document.dispatchEvent(e2);
 
                         // Debug overlay — shows key + LRUD state
                         if ('$eventType' === 'keydown') {

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // Minimal SW to enable PWA install on Samsung TV, Fire Stick, mobile, etc.
 // Does NOT cache aggressively — streaming content should always be live.
 
-const CACHE_NAME = 'streamvault-shell-v5';
+const CACHE_NAME = 'streamvault-shell-v6';
 const SHELL_ASSETS = [
   '/',
   '/manifest.json',

--- a/src/shared/hooks/useLRUD.ts
+++ b/src/shared/hooks/useLRUD.ts
@@ -32,10 +32,14 @@ export function useLRUD({ id, onEnter, onFocus, onBlur, parent = 'root', ...conf
     // Unregister first in case the node already exists (e.g. HMR, re-mount)
     try { lrud.unregisterNode(id); } catch { /* not registered yet */ }
 
-    // Register the node in the LRUD tree with parent
+    // Register the node in the LRUD tree with parent.
+    // @bam.tech/lrud considers a node focusable only if isFocusable=true or
+    // selectAction is set. Default leaf nodes (no orientation) to focusable.
+    const isFocusable = config.isFocusable ?? (config.orientation == null);
     lrud.registerNode(id, {
       parent,
       ...config,
+      isFocusable,
       onFocus: () => {
         setIsFocused(true);
         onFocusRef.current?.();

--- a/src/shared/providers/LRUDProvider.tsx
+++ b/src/shared/providers/LRUDProvider.tsx
@@ -37,9 +37,18 @@ export function LRUDProvider({ children }: LRUDProviderProps) {
       rootRegistered.current = true;
     }
 
+    // Dedup: Fire TV APK dispatches to both window AND document to handle
+    // cached vs fresh frontend. Skip if same key fires twice within 50ms.
+    let lastKeyTime = 0;
+    let lastKeyCode = '';
+
     // Handle keydown events to drive LRUD.
     // Use capture phase so we intercept before any child element can swallow the event.
     function handleKeyDown(e: KeyboardEvent) {
+      const now = Date.now();
+      if (e.key === lastKeyCode && now - lastKeyTime < 50) return;
+      lastKeyTime = now;
+      lastKeyCode = e.key;
       // Don't intercept keys when user is typing in an input — EXCEPT arrow
       // keys which should escape the input and navigate via LRUD
       const tag = (document.activeElement as HTMLElement)?.tagName;
@@ -100,14 +109,16 @@ export function LRUDProvider({ children }: LRUDProviderProps) {
       setInputMode('mouse');
     }
 
-    // Listen on document with capture phase. Fire TV native wrapper injects
-    // synthetic KeyboardEvents via evaluateJavascript() dispatched on document.
-    // Desktop browsers also bubble keydown from DOM elements up to document.
+    // Listen on BOTH document and window with capture phase.
+    // Fire TV APK dispatches synthetic KeyboardEvents to both targets.
+    // Dedup above prevents double-firing LRUD.
     document.addEventListener('keydown', handleKeyDown, { capture: true });
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
     window.addEventListener('mousemove', handleMouseMove, { passive: true });
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown, { capture: true });
+      window.removeEventListener('keydown', handleKeyDown, { capture: true });
       window.removeEventListener('mousemove', handleMouseMove);
     };
   }, [setInputMode]);


### PR DESCRIPTION
## Summary
- **Root cause fix**: `@bam.tech/lrud` only considers nodes focusable if `isFocusable=true` or `selectAction` is set. `useLRUD` hook passed `onSelect` but never set either flag — all nodes were treated as non-focusable containers, so `assignFocus('root')` silently found zero focusable descendants
- **Fix**: Leaf nodes (no `orientation`) now default to `isFocusable: true` in the `useLRUD` hook
- **Dual dispatch**: APK now dispatches key events to both `window` AND `document`, with JS-side 50ms dedup, ensuring the handler fires regardless of which cached frontend version the WebView loads
- **SW cache bump**: v5 → v6 to force fresh JS load on Fire Stick
- **gitignore**: Added APK build artifacts (`.apk`, `.idsig`, `.jks`, Gradle build dirs)

## Test plan
- [ ] Fire Stick: D-pad navigates between username/password/submit on login page
- [ ] Fire Stick: Debug overlay shows Focus: username-input (not NONE)
- [ ] Fire Stick: Enter key on focused input opens keyboard, on submit button triggers login
- [ ] Desktop browser: Arrow keys still navigate, mouse still works
- [ ] No regressions on authenticated pages (home, search, player)

🤖 Generated with [Claude Code](https://claude.com/claude-code)