### PR TITLE
feat: restructure LRUD navigation tree for Fire TV D-pad + fix player fullscreen

### DIFF
--- a/fire-tv/app/src/main/java/uk/srinivaskotha/streamvault/MainActivity.kt
+++ b/fire-tv/app/src/main/java/uk/srinivaskotha/streamvault/MainActivity.kt
@@ -4,7 +4,9 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.graphics.Color
 import android.os.Bundle
+import android.os.SystemClock
 import android.view.KeyEvent
+import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
 import android.webkit.CookieManager
@@ -178,7 +180,50 @@ class MainActivity : Activity() {
                     })();
                 """.trimIndent()
 
-                webView.evaluateJavascript(js, null)
+                webView.evaluateJavascript(js) { _ ->
+                    // After Enter keydown, check if JS focused an input element.
+                    // WebView needs a real touch event to create an InputConnection
+                    // that routes virtual keyboard input to the HTML <input>.
+                    // Programmatic .focus() + IMM.showSoftInput() opens the keyboard
+                    // but doesn't connect it to the input field.
+                    if (key == "Enter" && eventType == "keydown") {
+                        webView.evaluateJavascript("""
+                            (function() {
+                                var el = document.activeElement;
+                                if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA')) {
+                                    var r = el.getBoundingClientRect();
+                                    return JSON.stringify({x: r.left + r.width/2, y: r.top + r.height/2});
+                                }
+                                return 'null';
+                            })();
+                        """.trimIndent()) { result ->
+                            if (result != "\"null\"" && result != "null") {
+                                try {
+                                    val clean = result.trim('"').replace("\\\"", "\"")
+                                    val x = Regex(""""x":\s*([\d.]+)""").find(clean)?.groupValues?.get(1)?.toFloat() ?: return@evaluateJavascript
+                                    val y = Regex(""""y":\s*([\d.]+)""").find(clean)?.groupValues?.get(1)?.toFloat() ?: return@evaluateJavascript
+
+                                    // Account for WebView's device pixel ratio
+                                    val density = resources.displayMetrics.density
+                                    val tapX = x * density
+                                    val tapY = y * density
+
+                                    // Simulate a native touch tap — this triggers WebView's
+                                    // internal InputConnection setup for the HTML input.
+                                    val now = SystemClock.uptimeMillis()
+                                    val down = MotionEvent.obtain(now, now, MotionEvent.ACTION_DOWN, tapX, tapY, 0)
+                                    val up = MotionEvent.obtain(now, now + 50, MotionEvent.ACTION_UP, tapX, tapY, 0)
+                                    webView.dispatchTouchEvent(down)
+                                    webView.postDelayed({
+                                        webView.dispatchTouchEvent(up)
+                                        up.recycle()
+                                    }, 50)
+                                    down.recycle()
+                                } catch (_: Exception) { /* parsing failed, skip */ }
+                            }
+                        }
+                    }
+                }
                 return true  // Consume the event — don't let WebView handle it
             }
         }

--- a/src/features/home/components/HomePage.tsx
+++ b/src/features/home/components/HomePage.tsx
@@ -6,6 +6,7 @@ import { ContentRail } from '@shared/components/ContentRail';
 import { FocusableCard } from '@shared/components/FocusableCard';
 import { ContinueWatching } from './ContinueWatching';
 import { usePageFocus } from '@shared/hooks/usePageFocus';
+import { useLRUD } from '@shared/hooks/useLRUD';
 import {
   useLanguageMovieRail,
   useLanguageSeriesRail,
@@ -18,6 +19,14 @@ import type { XtreamVODStream } from '@shared/types/api';
 export function HomePage() {
   const navigate = useNavigate();
   usePageFocus('hero-banner');
+
+  const { ref: contentRef } = useLRUD({
+    id: 'home-content',
+    parent: 'root',
+    orientation: 'vertical',
+    isIndexAlign: true,
+    isFocusable: false,
+  });
 
   // Data hooks -- Telugu & Hindi movies and series
   const { items: teluguMovies, isLoading: teluguMoviesLoading } = useLanguageMovieRail('Telugu');
@@ -72,10 +81,10 @@ export function HomePage() {
 
   return (
     <PageTransition>
-      <div className="space-y-8 pb-12">
+      <div ref={contentRef} className="space-y-8 pb-12">
         {/* Hero Banner */}
         {heroItems.length > 0 && (
-          <HeroBanner items={heroItems} />
+          <HeroBanner items={heroItems} parentFocusKey="home-content" />
         )}
 
         {/* Continue Watching */}
@@ -87,6 +96,7 @@ export function HomePage() {
           seeAllTo="/language/telugu"
           isLoading={teluguMoviesLoading}
           isEmpty={!teluguMovies.length}
+          parentFocusKey="home-content"
         >
           {teluguMovies.map((item) => (
             <FocusableCard
@@ -107,6 +117,7 @@ export function HomePage() {
           seeAllTo="/language/telugu"
           isLoading={teluguSeriesLoading}
           isEmpty={!teluguSeries.length}
+          parentFocusKey="home-content"
         >
           {teluguSeries.map((item) => (
             <FocusableCard
@@ -127,6 +138,7 @@ export function HomePage() {
           seeAllTo="/language/hindi"
           isLoading={hindiMoviesLoading}
           isEmpty={!hindiMovies.length}
+          parentFocusKey="home-content"
         >
           {hindiMovies.map((item) => (
             <FocusableCard
@@ -147,6 +159,7 @@ export function HomePage() {
           seeAllTo="/language/hindi"
           isLoading={hindiSeriesLoading}
           isEmpty={!hindiSeries.length}
+          parentFocusKey="home-content"
         >
           {hindiSeries.map((item) => (
             <FocusableCard

--- a/src/features/live/components/ChannelCard.tsx
+++ b/src/features/live/components/ChannelCard.tsx
@@ -8,9 +8,10 @@ import { usePlayerStore, useUIStore } from '@lib/store';
 
 interface ChannelCardProps {
   channel: XtreamLiveStream;
+  parentFocusKey?: string;
 }
 
-export function ChannelCard({ channel }: ChannelCardProps) {
+export function ChannelCard({ channel, parentFocusKey }: ChannelCardProps) {
   const navigate = useNavigate();
   const playStream = usePlayerStore((s) => s.playStream);
   const inputMode = useUIStore((s) => s.inputMode);
@@ -28,7 +29,7 @@ export function ChannelCard({ channel }: ChannelCardProps) {
 
   const { ref, isFocused, focusProps } = useLRUD({
     id: `channel-${channel.stream_id}`,
-    parent: 'root',
+    parent: parentFocusKey || 'root',
     onEnter: handlePlay,
   });
 

--- a/src/features/live/components/ChannelGrid.tsx
+++ b/src/features/live/components/ChannelGrid.tsx
@@ -4,13 +4,14 @@ import { ChannelCard } from './ChannelCard';
 interface ChannelGridProps {
   channels: XtreamLiveStream[];
   focusKey?: string;
+  parentFocusKey?: string;
 }
 
-export function ChannelGrid({ channels }: ChannelGridProps) {
+export function ChannelGrid({ channels, parentFocusKey }: ChannelGridProps) {
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
       {channels.map((channel) => (
-        <ChannelCard key={channel.stream_id} channel={channel} />
+        <ChannelCard key={channel.stream_id} channel={channel} parentFocusKey={parentFocusKey} />
       ))}
     </div>
   );

--- a/src/features/live/components/FeaturedChannels.tsx
+++ b/src/features/live/components/FeaturedChannels.tsx
@@ -24,7 +24,7 @@ function FeaturedCard({ channel }: { channel: XtreamLiveStream }) {
 
   const { ref, isFocused, focusProps } = useLRUD({
     id: `featured-${channel.stream_id}`,
-    parent: 'root',
+    parent: 'featured-channels',
     onEnter: handleClick,
   });
 
@@ -98,8 +98,21 @@ function FeaturedCard({ channel }: { channel: XtreamLiveStream }) {
   );
 }
 
-export function FeaturedChannels() {
+interface FeaturedChannelsProps {
+  parentFocusKey?: string;
+}
+
+export function FeaturedChannels({ parentFocusKey = 'root' }: FeaturedChannelsProps) {
   const { data: channels, isLoading } = useFeaturedChannels();
+
+  // Register container for featured channel cards
+  const { ref: containerRef } = useLRUD({
+    id: 'featured-channels',
+    parent: parentFocusKey,
+    orientation: 'horizontal',
+    isWrapping: true,
+    isFocusable: false,
+  });
 
   if (isLoading) {
     return (
@@ -125,7 +138,7 @@ export function FeaturedChannels() {
         <span className="w-1.5 h-5 bg-gradient-to-b from-teal to-indigo rounded-full" />
         Featured Channels
       </h2>
-      <div className="flex gap-3 overflow-x-auto pb-2 scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent">
+      <div ref={containerRef} className="flex gap-3 overflow-x-auto pb-2 scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent">
         {channels.map((channel) => (
           <FeaturedCard key={channel.stream_id} channel={channel} />
         ))}

--- a/src/features/live/components/LivePage.tsx
+++ b/src/features/live/components/LivePage.tsx
@@ -80,7 +80,7 @@ function FocusableViewToggle({ isActive, onSelect, title, icon, id }: {
   id: string;
 }) {
   const inputMode = useUIStore((s) => s.inputMode);
-  const { ref, isFocused, focusProps } = useLRUD({ id, parent: 'live-main', onEnter: onSelect });
+  const { ref, isFocused, focusProps } = useLRUD({ id, parent: 'live-controls', onEnter: onSelect });
   const showFocus = isFocused && inputMode === 'keyboard';
 
   return (
@@ -110,7 +110,7 @@ function FocusableLiveSearch({ searchQuery, setSearchQuery }: {
   const inputMode = useUIStore((s) => s.inputMode);
   const { ref: focusRef, isFocused, focusProps } = useLRUD({
     id: 'live-search',
-    parent: 'live-main',
+    parent: 'live-controls',
     onEnter: () => inputRef.current?.focus(),
   });
   const showFocus = isFocused && inputMode === 'keyboard';
@@ -134,9 +134,9 @@ function FocusableLiveSearch({ searchQuery, setSearchQuery }: {
 function SidebarNav({ categories, activeCatId, isLoading, onSelect }: SidebarNavProps) {
   const { ref } = useLRUD({
     id: 'live-sidebar',
-    parent: 'root',
+    parent: 'live-layout',
     orientation: 'vertical',
-    isFocusable: false, // Structual wrapper for the sidebar layout
+    isFocusable: false,
   });
 
   return (
@@ -171,6 +171,47 @@ export function LivePage() {
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
   const debouncedSearch = useDebounce(searchQuery);
 
+  // Page container
+  const { ref: contentRef } = useLRUD({
+    id: 'live-content',
+    parent: 'root',
+    orientation: 'vertical',
+    isFocusable: false,
+  });
+
+  // Horizontal split: sidebar | main
+  const { ref: layoutRef } = useLRUD({
+    id: 'live-layout',
+    parent: 'live-content',
+    orientation: 'horizontal',
+    isFocusable: false,
+  });
+
+  // Main content area
+  const { ref: mainRef } = useLRUD({
+    id: 'live-main',
+    parent: 'live-layout',
+    orientation: 'vertical',
+    isFocusable: false,
+  });
+
+  // Controls bar (search + view toggles)
+  useLRUD({
+    id: 'live-controls',
+    parent: 'live-main',
+    orientation: 'horizontal',
+    isFocusable: false,
+  });
+
+  // Channel grid container
+  useLRUD({
+    id: 'live-channel-grid',
+    parent: 'live-main',
+    orientation: 'horizontal',
+    isWrapping: true,
+    isFocusable: false,
+  });
+
   const { data: categories, isLoading: catLoading } = useLiveCategories();
   const firstCatId = categories?.[0]?.category_id || '';
   const activeCatId = selectedCategory || firstCatId;
@@ -201,7 +242,7 @@ export function LivePage() {
 
   return (
     <PageTransition>
-    <div className="flex flex-col gap-4 h-full">
+    <div ref={contentRef} className="flex flex-col gap-4 h-full">
       {/* Inline Player */}
       {play && (
         <div className="relative">
@@ -225,9 +266,9 @@ export function LivePage() {
       )}
 
       {/* Featured Channels Section */}
-      {!play && <FeaturedChannels />}
+      {!play && <FeaturedChannels parentFocusKey="live-content" />}
 
-      <div className="flex gap-6 flex-1 min-h-0">
+      <div ref={layoutRef} className="flex gap-6 flex-1 min-h-0">
         {/* Category Sidebar — vertical focus boundary */}
         <SidebarNav
           categories={sortedCategories}
@@ -238,7 +279,7 @@ export function LivePage() {
 
 
         {/* Main Content */}
-        <div className="flex-1 min-w-0">
+        <div ref={mainRef} className="flex-1 min-w-0">
           {/* Top bar: Search + View toggle */}
           <div className="flex items-center gap-3 mb-4">
             <FocusableLiveSearch searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
@@ -285,7 +326,7 @@ export function LivePage() {
           ) : viewMode === 'epg' ? (
             <EPGGrid channels={filteredStreams} />
           ) : (
-            <ChannelGrid channels={filteredStreams} />
+            <ChannelGrid channels={filteredStreams} parentFocusKey="live-channel-grid" />
           )}
         </div>
       </div>

--- a/src/features/player/components/PlayerControls.tsx
+++ b/src/features/player/components/PlayerControls.tsx
@@ -335,12 +335,14 @@ export function PlayerControls({
           </>
         )}
 
-        {/* Fullscreen */}
-        <FocusableButton id="player-fullscreen" onClick={() => playerRef.current?.toggleFullscreen()} className="p-1.5 text-white/70 hover:text-white transition-colors" title="Fullscreen">
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
-          </svg>
-        </FocusableButton>
+        {/* Fullscreen — hidden in TV mode (already fullscreen) */}
+        {!isTVMode && (
+          <FocusableButton id="player-fullscreen" onClick={() => playerRef.current?.toggleFullscreen()} className="p-1.5 text-white/70 hover:text-white transition-colors" title="Fullscreen">
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
+            </svg>
+          </FocusableButton>
+        )}
       </div>
     </div>
   );

--- a/src/features/player/components/PlayerPage.tsx
+++ b/src/features/player/components/PlayerPage.tsx
@@ -118,15 +118,14 @@ export function PlayerPage({
     onClose,
   });
 
-  // Auto-fullscreen in TV mode (Fire Stick WebView, Samsung TV PWA)
+  // Auto-fullscreen — skip in TV mode (player div fills viewport via CSS)
+  // Only trigger for non-TV contexts (e.g. Samsung PWA that isn't in TV mode)
   useEffect(() => {
-    if (!isTVMode || !isPlaying) return;
-    // Small delay to let the video element mount before requesting fullscreen
+    if (isTVMode || !isPlaying) return;
     const timer = setTimeout(() => {
       playerRef.current?.toggleFullscreen();
     }, 300);
     return () => clearTimeout(timer);
-    // Only trigger once when playback starts, not on every isPlaying change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [streamId]);
 
@@ -141,7 +140,7 @@ export function PlayerPage({
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-[70vh] bg-obsidian rounded-xl">
+      <div className={`flex items-center justify-center ${isTVMode ? 'h-screen' : 'h-[70vh]'} bg-obsidian rounded-xl`}>
         <div className="text-center">
           <div className="w-12 h-12 border-4 border-teal/30 border-t-teal rounded-full animate-spin mx-auto mb-4" />
           <p className="text-text-secondary text-sm">Loading stream...</p>
@@ -152,7 +151,7 @@ export function PlayerPage({
 
   if (error || !streamData) {
     return (
-      <div className="flex items-center justify-center h-[70vh] bg-surface rounded-xl">
+      <div className={`flex items-center justify-center ${isTVMode ? 'h-screen' : 'h-[70vh]'} bg-surface rounded-xl`}>
         <div className="text-center">
           <svg className="w-12 h-12 text-error mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
@@ -170,10 +169,14 @@ export function PlayerPage({
     );
   }
 
+  const playerClass = isTVMode
+    ? 'fixed inset-0 w-screen h-screen z-50 bg-black'
+    : 'relative aspect-video bg-black rounded-xl overflow-hidden';
+
   return (
-    <div 
+    <div
       ref={ref}
-      className="relative aspect-video bg-black rounded-xl overflow-hidden focus:outline-none"
+      className={`${playerClass} focus:outline-none`}
       onMouseMove={showControls}
       onMouseLeave={() => isPlaying && setControlsVisible(false)}
       onClick={() => {

--- a/src/features/search/components/SearchPage.tsx
+++ b/src/features/search/components/SearchPage.tsx
@@ -71,7 +71,7 @@ function FocusableSearchInput({ inputRef, query, setQuery }: {
   const inputMode = useUIStore((s) => s.inputMode);
   const { ref: focusRef, isFocused, focusProps } = useLRUD({
     id: 'search-input',
-    parent: 'root',
+    parent: 'search-bar',
     onEnter: () => inputRef.current?.focus(),
   });
   const showFocus = isFocused && inputMode === 'keyboard';
@@ -149,6 +149,35 @@ export function SearchPage() {
   const navigate = useNavigate();
   const playStream = usePlayerStore((s) => s.playStream);
 
+  const { ref: contentRef } = useLRUD({
+    id: 'search-content',
+    parent: 'root',
+    orientation: 'vertical',
+    isFocusable: false,
+  });
+
+  useLRUD({
+    id: 'search-bar',
+    parent: 'search-content',
+    orientation: 'horizontal',
+    isFocusable: false,
+  });
+
+  useLRUD({
+    id: 'search-tabs',
+    parent: 'search-content',
+    orientation: 'horizontal',
+    isFocusable: false,
+  });
+
+  useLRUD({
+    id: 'search-results',
+    parent: 'search-content',
+    orientation: 'horizontal',
+    isWrapping: true,
+    isFocusable: false,
+  });
+
   const debouncedQuery = useDebounce(query, 300);
   const { data, isLoading, isFetching } = useSearch(debouncedQuery);
 
@@ -225,7 +254,7 @@ export function SearchPage() {
 
   return (
     <PageTransition>
-    <div className="space-y-6">
+    <div ref={contentRef} className="space-y-6">
       {/* Search Input */}
       <FocusableSearchInput inputRef={inputRef} query={query} setQuery={setQuery} />
 
@@ -234,7 +263,7 @@ export function SearchPage() {
         <div className="flex gap-2 overflow-x-auto scrollbar-hide pb-1">
           <FocusablePill
             id="search-lang-all"
-            parent="root"
+            parent="search-bar"
             label="All Languages"
             isActive={activeLang === null}
             onSelect={() => setActiveLang(null)}
@@ -242,7 +271,7 @@ export function SearchPage() {
           {languages.map((lang) => (
             <FocusablePill
               id={`search-lang-${lang}`}
-              parent="root"
+              parent="search-bar"
               key={lang}
               label={lang}
               isActive={activeLang === lang}
@@ -258,7 +287,7 @@ export function SearchPage() {
           {tabs.map((tab) => (
             <FocusableTab
               id={`search-tab-${tab.key}`}
-              parent="root"
+              parent="search-tabs"
               key={tab.key}
               label={tab.label}
               count={tab.count}
@@ -314,6 +343,7 @@ export function SearchPage() {
                     image={stream.stream_icon}
                     title={stream.name}
                     aspectRatio="square"
+                    parentFocusKey="search-results"
                     badge={
                       <span className="px-1.5 py-0.5 text-[10px] font-bold uppercase bg-red-500/90 text-white rounded">
                         Live
@@ -343,6 +373,7 @@ export function SearchPage() {
                     title={movie.name}
                     subtitle={movie.rating ? `${movie.rating}/10` : undefined}
                     aspectRatio="poster"
+                    parentFocusKey="search-results"
                     onClick={() => handleVodClick(movie.stream_id)}
                   />
                 ))}
@@ -367,6 +398,7 @@ export function SearchPage() {
                     title={show.name}
                     subtitle={show.genre || undefined}
                     aspectRatio="poster"
+                    parentFocusKey="search-results"
                     onClick={() => handleSeriesClick(show.series_id)}
                   />
                 ))}

--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -43,17 +43,19 @@ function FocusableEpisodeItem({
   ep,
   isPlaying,
   activeRef,
-  playEpisode
+  playEpisode,
+  parentFocusKey
 }: {
   ep: Episode;
   isPlaying: boolean;
   activeRef?: React.RefObject<HTMLDivElement | null>;
   playEpisode: (ep: Episode) => void;
+  parentFocusKey: string;
 }) {
   const inputMode = useUIStore((s) => s.inputMode);
   const { ref, isFocused, focusProps } = useLRUD({
     id: `series-ep-${ep.id}`,
-    parent: 'root',
+    parent: parentFocusKey,
     onEnter: () => playEpisode(ep),
   });
   
@@ -330,27 +332,48 @@ export function SeriesDetail() {
 
   const inputMode = useUIStore((s) => s.inputMode);
 
+  const { ref: contentRef } = useLRUD({
+    id: `series-content-${seriesId}`,
+    parent: 'root',
+    orientation: 'vertical',
+    isFocusable: false,
+  });
+
+  useLRUD({
+    id: `series-actions-${seriesId}`,
+    parent: `series-content-${seriesId}`,
+    orientation: 'horizontal',
+    isFocusable: false,
+  });
+
+  useLRUD({
+    id: `series-episodes-${seriesId}`,
+    parent: `series-content-${seriesId}`,
+    orientation: 'vertical',
+    isFocusable: false,
+  });
+
   const { ref: backRef, isFocused: backFocused, focusProps: backFocusProps } = useLRUD({
     id: `series-back-${seriesId}`,
-    parent: 'root',
+    parent: `series-actions-${seriesId}`,
     onEnter: () => navigate({ to: '/series' }),
   });
 
   const { ref: closeRef, isFocused: closeFocused, focusProps: closeFocusProps } = useLRUD({
     id: `series-close-${seriesId}`,
-    parent: 'root',
+    parent: `series-actions-${seriesId}`,
     onEnter: () => setPlayingEpisodeId(null),
   });
 
   const { ref: loadMoreRef, isFocused: loadMoreFocused, focusProps: loadMoreFocusProps } = useLRUD({
     id: `series-load-more-${seriesId}`,
-    parent: 'root',
+    parent: `series-episodes-${seriesId}`,
     onEnter: handleLoadMore,
   });
 
   const { ref: resumeRef, isFocused: resumeFocused, focusProps: resumeFocusProps } = useLRUD({
     id: `series-resume-${seriesId}`,
-    parent: 'root',
+    parent: `series-actions-${seriesId}`,
     onEnter: () => {
       if (!lastWatchedEpisode) return;
       setPlayingEpisodeId(String(lastWatchedEpisode.content_id));
@@ -387,7 +410,7 @@ export function SeriesDetail() {
 
   return (
     <PageTransition>
-      <div className="pb-12">
+      <div ref={contentRef} className="pb-12">
         {/* Back button */}
         <div className="px-6 lg:px-10 pt-4 mb-4">
           <button
@@ -690,6 +713,7 @@ export function SeriesDetail() {
                   isPlaying={isPlaying}
                   activeRef={highlightRef}
                   playEpisode={playEpisode}
+                  parentFocusKey={`series-episodes-${seriesId}`}
                 />
               );
             })

--- a/src/features/vod/components/MovieDetail.tsx
+++ b/src/features/vod/components/MovieDetail.tsx
@@ -29,21 +29,35 @@ export function MovieDetail() {
     return entry?.progress_seconds ?? 0;
   }, [watchHistory, vodId]);
 
+  const { ref: contentRef } = useLRUD({
+    id: `movie-content-${vodId}`,
+    parent: 'root',
+    orientation: 'vertical',
+    isFocusable: false,
+  });
+
+  useLRUD({
+    id: `movie-actions-${vodId}`,
+    parent: `movie-content-${vodId}`,
+    orientation: 'horizontal',
+    isFocusable: false,
+  });
+
   const { ref: backRef, isFocused: backFocused, focusProps: backFocusProps } = useLRUD({
     id: `vod-back-${vodId}`,
-    parent: 'root',
+    parent: `movie-actions-${vodId}`,
     onEnter: () => navigate({ to: '/vod' }),
   });
 
   const { ref: closeRef, isFocused: closeFocused, focusProps: closeFocusProps } = useLRUD({
     id: `vod-close-${vodId}`,
-    parent: 'root',
+    parent: `movie-actions-${vodId}`,
     onEnter: () => setIsPlayerOpen(false),
   });
 
   const { ref: playRef, isFocused: playFocused, focusProps: playFocusProps } = useLRUD({
     id: `vod-play-${vodId}`,
-    parent: 'root',
+    parent: `movie-actions-${vodId}`,
     onEnter: () => setIsPlayerOpen(true),
   });
 
@@ -71,7 +85,7 @@ export function MovieDetail() {
   const { info, movie_data } = data;
 
   return (
-    <div>
+    <div ref={contentRef}>
       {/* Back button */}
       <button
         ref={backRef}

--- a/src/features/vod/components/VODPage.tsx
+++ b/src/features/vod/components/VODPage.tsx
@@ -23,7 +23,7 @@ function FocusableSearchInput({ searchQuery, setSearchQuery }: {
   const inputMode = useUIStore((s) => s.inputMode);
   const { ref: focusRef, isFocused, focusProps } = useLRUD({
     id: 'vod-search-input',
-    parent: 'root',
+    parent: 'vod-controls',
     onEnter: () => inputRef.current?.focus(),
   });
   const showFocus = isFocused && inputMode === 'keyboard';
@@ -51,6 +51,28 @@ export function VODPage() {
   const [sort, setSort] = useState<SortOption>(SORT_OPTIONS[0]!);
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
   const debouncedSearch = useDebounce(searchQuery);
+
+  const { ref: contentRef } = useLRUD({
+    id: 'vod-content',
+    parent: 'root',
+    orientation: 'vertical',
+    isFocusable: false,
+  });
+
+  useLRUD({
+    id: 'vod-controls',
+    parent: 'vod-content',
+    orientation: 'horizontal',
+    isFocusable: false,
+  });
+
+  useLRUD({
+    id: 'vod-grid',
+    parent: 'vod-content',
+    orientation: 'horizontal',
+    isWrapping: true,
+    isFocusable: false,
+  });
 
   const { data: categories, isLoading: catLoading } = useVODCategories();
   const firstCatId = categories?.[0]?.category_id || '';
@@ -84,7 +106,7 @@ export function VODPage() {
 
   return (
     <PageTransition>
-    <div>
+    <div ref={contentRef}>
       <h1 className="font-display text-2xl font-bold text-text-primary mb-4">Movies</h1>
 
       {/* Categories */}
@@ -130,6 +152,7 @@ export function VODPage() {
               image={movie.stream_icon}
               title={movie.name}
               subtitle={parseGenres(movie.container_extension).length > 0 ? movie.container_extension.toUpperCase() : undefined}
+              parentFocusKey="vod-grid"
               badge={
                 movie.rating_5based > 0 ? (
                   <Badge variant="warning">{movie.rating_5based.toFixed(1)} ★</Badge>

--- a/src/shared/components/ContentCard.tsx
+++ b/src/shared/components/ContentCard.tsx
@@ -2,6 +2,7 @@ import { useCallback, type ReactNode } from 'react';
 import { useLRUD } from '@shared/hooks/useLRUD';
 import { LazyImage } from './LazyImage';
 import { useUIStore } from '@lib/store';
+import { useRailParent } from './ContentRail';
 
 interface ContentCardProps {
   image: string;
@@ -67,6 +68,7 @@ export function ContentCard({
   parentFocusKey,
 }: ContentCardProps) {
   const inputMode = useUIStore((s) => s.inputMode);
+  const railParent = useRailParent();
 
   const onEnterPress = useCallback(() => {
     onClick?.();
@@ -74,7 +76,7 @@ export function ContentCard({
 
   const { ref, isFocused, focusProps } = useLRUD({
     id: propFocusKey || `card-${title.replace(/\s+/g, '-').toLowerCase()}`,
-    parent: parentFocusKey || 'root',
+    parent: parentFocusKey || railParent,
     onEnter: onEnterPress,
   });
 

--- a/src/shared/components/ContentRail.tsx
+++ b/src/shared/components/ContentRail.tsx
@@ -1,8 +1,11 @@
-import { type ReactNode } from 'react';
+import { createContext, useContext, type ReactNode } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useLRUD } from '@shared/hooks/useLRUD';
 import { useUIStore } from '@lib/store';
 import { HorizontalScroll } from './HorizontalScroll';
+
+const RailContext = createContext<string>('root');
+export function useRailParent() { return useContext(RailContext); }
 
 
 interface ContentRailProps {
@@ -14,6 +17,7 @@ interface ContentRailProps {
   isEmpty?: boolean;
   isLoading?: boolean;
   focusKey?: string;
+  parentFocusKey?: string;
 }
 
 function FocusableSeeAll({ to, parentFocusKey }: { to: string; parentFocusKey: string }) {
@@ -55,12 +59,15 @@ export function ContentRail({
   isEmpty = false,
   isLoading = false,
   focusKey: propFocusKey,
+  parentFocusKey = 'root',
 }: ContentRailProps) {
   const focusKeyId = propFocusKey || `rail-${title.replace(/\s+/g, '-').toLowerCase()}`;
 
   const { ref } = useLRUD({
     id: focusKeyId,
-    parent: 'root',
+    parent: parentFocusKey,
+    orientation: 'horizontal',
+    isWrapping: true,
     isFocusable: false, // Structural node that groups children
   });
 
@@ -92,7 +99,9 @@ export function ContentRail({
             </div>
           ) : (
             <HorizontalScroll>
-              {children}
+              <RailContext.Provider value={focusKeyId}>
+                {children}
+              </RailContext.Provider>
             </HorizontalScroll>
           )}
         </div>

--- a/src/shared/components/HeroBanner.tsx
+++ b/src/shared/components/HeroBanner.tsx
@@ -17,6 +17,7 @@ export interface HeroItem {
 interface HeroBannerProps {
   items: HeroItem[];
   autoRotateMs?: number;
+  parentFocusKey?: string;
 }
 
 function HeroButton({
@@ -52,7 +53,7 @@ function HeroButton({
   );
 }
 
-export function HeroBanner({ items, autoRotateMs = 8000 }: HeroBannerProps) {
+export function HeroBanner({ items, autoRotateMs = 8000, parentFocusKey = 'root' }: HeroBannerProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const navigate = useNavigate();
   const playStream = usePlayerStore((s) => s.playStream);
@@ -62,7 +63,7 @@ export function HeroBanner({ items, autoRotateMs = 8000 }: HeroBannerProps) {
 
   const { ref: heroRef } = useLRUD({
     id: 'hero-banner',
-    parent: 'root',
+    parent: parentFocusKey,
     isFocusable: false,
     orientation: 'horizontal',
   });

--- a/src/shared/components/HorizontalScroll.tsx
+++ b/src/shared/components/HorizontalScroll.tsx
@@ -1,27 +1,16 @@
-import { useRef, useState, useEffect, useCallback, useId, type ReactNode } from 'react';
+import { useRef, useState, useEffect, useCallback, type ReactNode } from 'react';
 import { useUIStore } from '@lib/store';
-import { useLRUD } from '@shared/hooks/useLRUD';
+import { isTVMode } from '@shared/utils/isTVMode';
 
-function FocusableScrollArrow({ direction, onClick, arrowOpacity, instanceId }: {
+function ScrollArrow({ direction, onClick, arrowOpacity }: {
   direction: 'left' | 'right';
   onClick: () => void;
   arrowOpacity: string;
-  instanceId: string;
 }) {
-  const inputMode = useUIStore((s) => s.inputMode);
-  const { ref, isFocused, focusProps } = useLRUD({
-    id: `scroll-arrow-${direction}-${instanceId}`,
-    parent: 'root',
-    onEnter: onClick,
-  });
-  const showFocus = isFocused && inputMode === 'keyboard';
-
   return (
     <button
-      ref={ref}
-      {...focusProps}
       onClick={onClick}
-      className={`absolute ${direction === 'left' ? 'left-0' : 'right-0'} top-1/2 -translate-y-1/2 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-obsidian/80 border border-border-subtle text-text-primary transition-opacity duration-200 hover:bg-surface-raised hover:border-teal/30 ${showFocus ? 'opacity-100 ring-2 ring-teal' : arrowOpacity}`}
+      className={`absolute ${direction === 'left' ? 'left-0' : 'right-0'} top-1/2 -translate-y-1/2 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-obsidian/80 border border-border-subtle text-text-primary transition-opacity duration-200 hover:bg-surface-raised hover:border-teal/30 ${arrowOpacity}`}
       aria-label={`Scroll ${direction}`}
     >
       <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -37,7 +26,6 @@ interface HorizontalScrollProps {
 }
 
 export function HorizontalScroll({ children, className = '' }: HorizontalScrollProps) {
-  const instanceId = useId();
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
@@ -82,9 +70,9 @@ export function HorizontalScroll({ children, className = '' }: HorizontalScrollP
 
   return (
     <div className={`group/scroll relative ${className}`}>
-      {/* Left arrow */}
-      {canScrollLeft && (
-        <FocusableScrollArrow direction="left" onClick={() => scroll('left')} arrowOpacity={arrowOpacity} instanceId={instanceId} />
+      {/* Left arrow — hidden in TV mode (D-pad users scroll via focus + scrollIntoView) */}
+      {!isTVMode && canScrollLeft && (
+        <ScrollArrow direction="left" onClick={() => scroll('left')} arrowOpacity={arrowOpacity} />
       )}
 
       {/* Scrollable area */}
@@ -95,9 +83,9 @@ export function HorizontalScroll({ children, className = '' }: HorizontalScrollP
         {children}
       </div>
 
-      {/* Right arrow */}
-      {canScrollRight && (
-        <FocusableScrollArrow direction="right" onClick={() => scroll('right')} arrowOpacity={arrowOpacity} instanceId={instanceId} />
+      {/* Right arrow — hidden in TV mode */}
+      {!isTVMode && canScrollRight && (
+        <ScrollArrow direction="right" onClick={() => scroll('right')} arrowOpacity={arrowOpacity} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Restructure flat LRUD tree (21+ nodes all under root) into Netflix-style nested hierarchy for correct D-pad navigation across all pages
- Fix player blank screen on Fire TV: use viewport-filling CSS (`fixed inset-0`) instead of broken Fullscreen API in WebView
- Include uncommitted touch simulation for keyboard input from previous session

### LRUD Tree Changes (13 files)
- **ContentRail**: `orientation: 'horizontal'` + `isWrapping: true` + RailContext for auto-parenting child cards
- **ContentCard**: consume RailContext, fall back to parent instead of root
- **HorizontalScroll**: remove LRUD from scroll arrows (mouse-only), hide entirely in TV mode
- **HomePage**: `home-content` vertical container with `isIndexAlign: true`
- **HeroBanner**: accept `parentFocusKey` prop
- **LivePage**: full restructure → `live-layout` (horizontal) splits sidebar and main
- **SearchPage**: `search-bar`, `search-tabs`, `search-results` containers
- **VODPage**: `vod-controls` + `vod-grid` containers
- **SeriesDetail**: `series-actions` + `series-episodes` containers
- **MovieDetail**: `movie-actions` container

### Player Fix
- **PlayerPage**: TV mode uses `fixed inset-0 w-screen h-screen z-50` instead of `aspect-video` + Fullscreen API
- **PlayerControls**: hide fullscreen button in TV mode (already fullscreen)

### Fire TV APK
- **MainActivity.kt**: touch simulation for keyboard input on Enter (MotionEvent at input coordinates)

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] Fire Stick: Home page — D-pad DOWN moves hero → rail 1 → rail 2, LEFT/RIGHT scrolls cards within rail
- [ ] Fire Stick: Live page — LEFT/RIGHT moves sidebar ↔ main, UP/DOWN within sidebar
- [ ] Fire Stick: Search — LEFT/RIGHT across language pills and tabs, DOWN to results
- [ ] Fire Stick: Player — video fills screen (no blank/black), LEFT/RIGHT across controls
- [ ] Desktop browser: arrow key nav + mouse hover still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)