### PR TITLE
fix: LRUD capture-phase race + profile menu focus escape

### DIFF
--- a/src/features/player/components/PlayerPage.tsx
+++ b/src/features/player/components/PlayerPage.tsx
@@ -5,7 +5,7 @@ import { PlayerControls } from './PlayerControls';
 import { usePlayerKeyboard } from '../hooks/usePlayerKeyboard';
 import { isTVMode } from '@shared/utils/isTVMode';
 import { useProgressTracking } from '../hooks/useProgressTracking';
-import { usePlayerStore } from '@lib/store';
+import { usePlayerStore, useUIStore } from '@lib/store';
 import { useLRUD } from '@shared/hooks/useLRUD';
 import { useLRUDContext } from '@shared/providers/LRUDProvider';
 
@@ -108,15 +108,21 @@ export function PlayerPage({
     isFocusable: false,
   });
 
-  // In TV mode, auto-focus play/pause when player mounts
+  // In TV mode: suppress LRUD arrow navigation (player handles seek/volume),
+  // and auto-focus play/pause when player mounts
+  const setSuppressArrowNav = useUIStore((s) => s.setSuppressArrowNav);
   useEffect(() => {
     if (isTVMode) {
+      setSuppressArrowNav(true);
       const timer = setTimeout(() => {
         try { lrud.assignFocus('player-play-pause'); } catch { /* not registered yet */ }
       }, 100);
-      return () => clearTimeout(timer);
+      return () => {
+        clearTimeout(timer);
+        setSuppressArrowNav(false);
+      };
     }
-  }, [streamId, lrud]);
+  }, [streamId, lrud, setSuppressArrowNav]);
 
   // Keep controls visible if user is navigating controls with D-pad
   useEffect(() => {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -29,6 +29,9 @@ interface UIState {
   setSidebarOpen: (open: boolean) => void;
   inputMode: 'mouse' | 'keyboard';
   setInputMode: (mode: 'mouse' | 'keyboard') => void;
+  /** When true, LRUDProvider skips arrow key handling (e.g. player captures arrows for seek/volume) */
+  suppressArrowNav: boolean;
+  setSuppressArrowNav: (suppress: boolean) => void;
 }
 
 export const useUIStore = create<UIState>((set) => ({
@@ -37,6 +40,8 @@ export const useUIStore = create<UIState>((set) => ({
   setSidebarOpen: (open) => set({ sidebarOpen: open }),
   inputMode: 'mouse' as const,
   setInputMode: (mode) => set({ inputMode: mode }),
+  suppressArrowNav: false,
+  setSuppressArrowNav: (suppress) => set({ suppressArrowNav: suppress }),
 }));
 
 export type StreamType = 'live' | 'vod' | 'series';

--- a/src/shared/components/TopNav.tsx
+++ b/src/shared/components/TopNav.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Link, useMatchRoute, useNavigate } from '@tanstack/react-router';
 import { useLRUD } from '@shared/hooks/useLRUD';
+import { useLRUDContext } from '@shared/providers/LRUDProvider';
 import { useAuthStore, useUIStore } from '@lib/store';
 import { useLogout } from '@features/auth/hooks/useAuth';
 import { useLiveCategories } from '@features/live/api';
@@ -257,6 +258,17 @@ function ProfileMenu({
 }) {
   const navigate = useNavigate();
   const inputMode = useUIStore((s) => s.inputMode);
+  const { lrud } = useLRUDContext();
+  const prevProfileOpen = useRef(profileOpen);
+
+  // When profile menu closes, reassign focus to profile button to prevent
+  // LRUD focus from being stranded on now-invisible menu items
+  useEffect(() => {
+    if (prevProfileOpen.current && !profileOpen) {
+      try { lrud.assignFocus('profile-btn'); } catch { /* noop */ }
+    }
+    prevProfileOpen.current = profileOpen;
+  }, [profileOpen, lrud]);
 
   // Register the profile-menu LRUD container so dropdown children have a parent
   const { ref: menuRef } = useLRUD({

--- a/src/shared/providers/LRUDProvider.tsx
+++ b/src/shared/providers/LRUDProvider.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useEffect, useRef, type ReactNode } from 'react';
 import { Lrud } from '@bam.tech/lrud';
 import { useUIStore } from '@lib/store';
+// Note: useUIStore.getState() is used directly (not as a hook) inside the keydown handler
+// to read suppressArrowNav synchronously without re-rendering LRUDProvider.
 
 // Create a global singleton instance of LRUD for the app
 export const lrud = new Lrud();
@@ -58,6 +60,10 @@ export function LRUDProvider({ children }: LRUDProviderProps) {
 
       // Let non-arrow keys through to inputs normally
       if (isInInput && !isArrow) return;
+
+      // When suppressArrowNav is true (e.g. player is active in TV mode),
+      // skip arrow handling so usePlayerKeyboard can handle seek/volume exclusively
+      if (isArrow && useUIStore.getState().suppressArrowNav) return;
 
       const isNavKey = isArrow || ['Enter', 'Escape', 'Backspace'].includes(e.key);
 


### PR DESCRIPTION
## Summary
- **LRUD arrow suppression in TV player**: LRUDProvider's capture-phase handler fired before `usePlayerKeyboard`, causing double-firing (LRUD navigation + seek) on arrow keys. Added `suppressArrowNav` flag to UIStore — PlayerPage sets it on mount in TV mode, LRUDProvider skips arrow handling when set.
- **Profile menu focus escape**: When profile dropdown closes, LRUD focus could remain on invisible menu items (fav/history/logout). Added `useEffect` that calls `lrud.assignFocus('profile-btn')` when `profileOpen` transitions to false.

Addresses HIGH findings from quality review of PR #38.

## Test plan
- [ ] Fire Stick: Player LEFT/RIGHT only seeks (no LRUD button movement)
- [ ] Fire Stick: Player UP/DOWN only adjusts volume
- [ ] Fire Stick: Open profile menu, navigate to Favorites, close menu — focus returns to profile button
- [ ] Desktop: arrow keys still work normally in non-player pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)