### PR TITLE
feat: add TV mode simulation for desktop testing

### DIFF
--- a/src/shared/utils/isTVMode.ts
+++ b/src/shared/utils/isTVMode.ts
@@ -3,10 +3,21 @@
  * - PWA standalone mode (Samsung TV, TWA with Chrome)
  * - Native WebView wrapper (Fire Stick — no display-mode: standalone, but
  *   user agent includes "FireTV" set by our MainActivity.kt)
+ * - Dev override: ?tv=1 in URL or localStorage.setItem('sv_tv_mode', '1')
  *
  * Used to hide desktop-only controls (PiP, fullscreen) and enable D-pad
  * focus management.
  */
+const tvOverride =
+  new URLSearchParams(window.location.search).get('tv') === '1' ||
+  localStorage.getItem('sv_tv_mode') === '1';
+
+// Persist URL param to localStorage so it survives page navigations
+if (new URLSearchParams(window.location.search).get('tv') === '1') {
+  localStorage.setItem('sv_tv_mode', '1');
+}
+
 export const isTVMode =
+  tvOverride ||
   window.matchMedia('(display-mode: standalone)').matches ||
   /FireTV|AFT|Silk\/\d|AFTM|AFTT|AFTS/i.test(navigator.userAgent);


### PR DESCRIPTION
## Summary
- Add `?tv=1` URL param to force TV mode on desktop browser
- Persists via localStorage (`sv_tv_mode`) across page navigations
- Remove with `localStorage.removeItem('sv_tv_mode')` + refresh

## How to test
1. Open `https://streamvault.srinivaskotha.uk/?tv=1`
2. Set Chrome DevTools to 1920x1080
3. Use arrow keys as D-pad, Enter as OK, Escape as Back
4. Verify: minimal TopNav (logo + profile only), compact cards, no scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)