### PR TITLE
fix: resolve 9 TV UX issues — D-pad nav, player OSD, continue watching

### DIFF
--- a/src/features/history/api.ts
+++ b/src/features/history/api.ts
@@ -19,3 +19,15 @@ export function useClearHistory() {
     },
   });
 }
+
+export function useRemoveHistoryItem() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ contentId, contentType }: { contentId: number; contentType: string }) => {
+      return api<void>(`/history/${contentId}?content_type=${contentType}`, { method: 'DELETE' });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['history'] });
+    },
+  });
+}

--- a/src/features/home/components/ContinueWatching.tsx
+++ b/src/features/home/components/ContinueWatching.tsx
@@ -1,4 +1,5 @@
 import { useWatchHistory } from '../api';
+import { useRemoveHistoryItem } from '@features/history/api';
 import { useNavigate } from '@tanstack/react-router';
 import { usePlayerStore, type StreamType } from '@lib/store';
 import { ContentRail } from '@shared/components/ContentRail';
@@ -12,6 +13,7 @@ const contentTypeToStreamType: Record<string, StreamType> = {
 
 export function ContinueWatching() {
   const { data: history, isLoading } = useWatchHistory();
+  const removeHistoryItem = useRemoveHistoryItem();
   const playStream = usePlayerStore((s) => s.playStream);
   const navigate = useNavigate();
 
@@ -59,6 +61,10 @@ export function ContinueWatching() {
             subtitle={`${percent}% watched`}
             progress={percent}
             aspectRatio="landscape"
+            onRemove={() => removeHistoryItem.mutate({
+              contentId: item.content_id,
+              contentType: item.content_type,
+            })}
             onClick={() => handleClick(item)}
           />
         );

--- a/src/features/home/components/HomePage.tsx
+++ b/src/features/home/components/HomePage.tsx
@@ -1,10 +1,10 @@
+import { useEffect } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { PageTransition } from '@shared/components/PageTransition';
 import { ContentRail } from '@shared/components/ContentRail';
 import { FocusableCard } from '@shared/components/FocusableCard';
 import { ContinueWatching } from './ContinueWatching';
-import { usePageFocus } from '@shared/hooks/usePageFocus';
-import { useSpatialContainer, FocusContext } from '@shared/hooks/useSpatialNav';
+import { useSpatialContainer, FocusContext, setFocus } from '@shared/hooks/useSpatialNav';
 import {
   useLanguageMovieRail,
   useLanguageSeriesRail,
@@ -16,11 +16,11 @@ import type { XtreamVODStream } from '@shared/types/api';
 
 export function HomePage() {
   const navigate = useNavigate();
-  usePageFocus('home-content');
 
   const { ref: contentRef, focusKey } = useSpatialContainer({
     focusKey: 'home-content',
     forceFocus: true,
+    autoRestoreFocus: true,
   });
 
   // Data hooks -- Telugu & Hindi movies and series
@@ -28,6 +28,18 @@ export function HomePage() {
   const { items: teluguSeries, isLoading: teluguSeriesLoading } = useLanguageSeriesRail('Telugu');
   const { items: hindiMovies, isLoading: hindiMoviesLoading } = useLanguageMovieRail('Hindi');
   const { items: hindiSeries, isLoading: hindiSeriesLoading } = useLanguageSeriesRail('Hindi');
+
+  // Auto-focus first available content after data loads
+  const allLoading = teluguMoviesLoading || teluguSeriesLoading || hindiMoviesLoading || hindiSeriesLoading;
+
+  useEffect(() => {
+    if (allLoading) return;
+    // Data loaded — focus the first rail
+    const timer = setTimeout(() => {
+      try { setFocus('home-content'); } catch { /* noop */ }
+    }, 150);
+    return () => clearTimeout(timer);
+  }, [allLoading]);
 
   const handleVodClick = (item: XtreamVODStream) => {
     navigate({ to: '/vod/$vodId', params: { vodId: String(item.stream_id) } });

--- a/src/features/language/components/LiveTabContent.tsx
+++ b/src/features/language/components/LiveTabContent.tsx
@@ -155,7 +155,7 @@ export function LiveTabContent({ language, lang }: LiveTabContentProps) {
       {/* Content: Rails mode (no filters) or Grid mode (filters active) */}
       {isLoading ? (
         hasActiveFilters ? (
-          <SkeletonGrid count={24} aspectRatio="square" />
+          <SkeletonGrid count={24} aspectRatio="landscape" />
         ) : (
           <ContentRail title="Loading..." isLoading={true}>
             <div />
@@ -185,7 +185,7 @@ export function LiveTabContent({ language, lang }: LiveTabContentProps) {
                   key={channel.stream_id}
                   image={channel.stream_icon}
                   title={channel.name}
-                  aspectRatio="square"
+                  aspectRatio="landscape"
                   onClick={() => handlePlay(channel)}
                 />
               ))}
@@ -208,7 +208,7 @@ export function LiveTabContent({ language, lang }: LiveTabContentProps) {
                   image={item.stream_icon}
                   title={item.name}
                   isNew={isNewContent(item.added)}
-                  aspectRatio="square"
+                  aspectRatio="landscape"
                   onClick={() => handlePlay(item)}
                 />
               ))}

--- a/src/features/player/components/PlayerOSD.tsx
+++ b/src/features/player/components/PlayerOSD.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+
+export interface OSDAction {
+  type: 'seek-back' | 'seek-forward' | 'volume' | 'play' | 'pause' | 'mute' | 'unmute';
+  value?: number; // volume level 0-1, or seek seconds
+  timestamp: number; // Date.now() to trigger re-renders on same action
+}
+
+export function PlayerOSD({ action }: { action: OSDAction | null }) {
+  const [visible, setVisible] = useState(false);
+  const [currentAction, setCurrentAction] = useState<OSDAction | null>(null);
+
+  useEffect(() => {
+    if (!action) return;
+    setCurrentAction(action);
+    setVisible(true);
+    const timer = setTimeout(() => setVisible(false), 1200);
+    return () => clearTimeout(timer);
+  }, [action]);
+
+  if (!visible || !currentAction) return null;
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-40">
+      <div className="bg-black/70 rounded-2xl px-8 py-6 text-white text-center backdrop-blur-sm animate-in fade-in duration-150">
+        {renderOSDContent(currentAction)}
+      </div>
+    </div>
+  );
+}
+
+function renderOSDContent(action: OSDAction) {
+  switch (action.type) {
+    case 'seek-back':
+      return (
+        <div className="flex flex-col items-center gap-2">
+          <svg className="w-10 h-10" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12.5 3C7.81 3 4.01 6.54 3.57 11H1l3.5 4 3.5-4H5.59c.44-3.36 3.3-6 6.91-6 3.87 0 7 3.13 7 7s-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42C7.82 20.04 10.05 21 12.5 21c4.97 0 9-4.03 9-9s-4.03-9-9-9z" />
+            <text x="10" y="15.5" fontSize="7.5" fontWeight="bold" textAnchor="middle" fill="currentColor">10</text>
+          </svg>
+          <span className="text-sm font-medium">-10s</span>
+        </div>
+      );
+    case 'seek-forward':
+      return (
+        <div className="flex flex-col items-center gap-2">
+          <svg className="w-10 h-10" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M11.5 3c4.69 0 8.49 3.54 8.93 8H23l-3.5 4-3.5-4h2.02c-.44-3.36-3.3-6-6.91-6-3.87 0-7 3.13-7 7s3.13 7 7 7c1.93 0 3.68-.79 4.94-2.06l1.42 1.42C15.68 20.04 13.45 21 11.5 21c-4.97 0-9-4.03-9-9s4.03-9 9-9z" />
+            <text x="14" y="15.5" fontSize="7.5" fontWeight="bold" textAnchor="middle" fill="currentColor">10</text>
+          </svg>
+          <span className="text-sm font-medium">+10s</span>
+        </div>
+      );
+    case 'volume':
+      return (
+        <div className="flex flex-col items-center gap-2">
+          <svg className="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
+          </svg>
+          <div className="w-32 h-1.5 bg-white/20 rounded-full overflow-hidden">
+            <div className="h-full bg-teal rounded-full transition-all" style={{ width: `${Math.round((action.value ?? 0) * 100)}%` }} />
+          </div>
+          <span className="text-sm font-medium">{Math.round((action.value ?? 0) * 100)}%</span>
+        </div>
+      );
+    case 'play':
+      return (
+        <svg className="w-14 h-14" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M8 5v14l11-7z" />
+        </svg>
+      );
+    case 'pause':
+      return (
+        <svg className="w-14 h-14" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M6 4h4v16H6zm8 0h4v16h-4z" />
+        </svg>
+      );
+    case 'mute':
+      return (
+        <div className="flex flex-col items-center gap-2">
+          <svg className="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2" />
+          </svg>
+          <span className="text-sm font-medium">Muted</span>
+        </div>
+      );
+    case 'unmute':
+      return (
+        <div className="flex flex-col items-center gap-2">
+          <svg className="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
+          </svg>
+          <span className="text-sm font-medium">Unmuted</span>
+        </div>
+      );
+  }
+}

--- a/src/features/player/components/PlayerPage.tsx
+++ b/src/features/player/components/PlayerPage.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useCallback, useEffect } from 'react';
 import { useStreamUrl } from '../api';
 import { VideoPlayer, type VideoPlayerHandle, type QualityLevel } from './VideoPlayer';
 import { PlayerControls } from './PlayerControls';
+import { PlayerOSD, type OSDAction } from './PlayerOSD';
 import { usePlayerKeyboard } from '../hooks/usePlayerKeyboard';
 import { isTVMode } from '@shared/utils/isTVMode';
 import { useProgressTracking } from '../hooks/useProgressTracking';
@@ -44,6 +45,7 @@ export function PlayerPage({
   const [qualityLevels, setQualityLevels] = useState<QualityLevel[]>([]);
   const [currentQuality, setCurrentQuality] = useState(-1);
   const [error, setError] = useState<string | null>(null);
+  const [osdAction, setOsdAction] = useState<OSDAction | null>(null);
 
   const [controlsVisible, setControlsVisible] = useState(true);
   const controlsTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -86,6 +88,16 @@ export function PlayerPage({
     controlsTimeoutRef.current = setTimeout(() => {
       setControlsVisible(false);
     }, 4000);
+  }, []);
+
+  const handleOSD = useCallback((action: { type: string; timestamp: number }) => {
+    const vol = usePlayerStore.getState().volume;
+    const isMut = usePlayerStore.getState().isMuted;
+    setOsdAction({
+      type: action.type as OSDAction['type'],
+      value: action.type === 'volume' ? (isMut ? 0 : vol) : undefined,
+      timestamp: action.timestamp,
+    });
   }, []);
 
   // Show controls when paused
@@ -131,6 +143,7 @@ export function PlayerPage({
     onVolumeUp: handleVolumeUp,
     onVolumeDown: handleVolumeDown,
     onClose,
+    onOSD: handleOSD,
   });
 
   // Auto-fullscreen — skip in TV mode (player div fills viewport via CSS)
@@ -234,6 +247,7 @@ export function PlayerPage({
           onPrev={onPrev}
           visible={controlsVisible}
         />
+        <PlayerOSD action={osdAction} />
         {streamName && (
           <div className="absolute top-4 left-4 text-white/80 text-sm font-medium bg-obsidian/50 px-3 py-1 rounded-lg backdrop-blur-sm">
             {streamName}

--- a/src/features/player/hooks/usePlayerKeyboard.ts
+++ b/src/features/player/hooks/usePlayerKeyboard.ts
@@ -11,6 +11,7 @@ interface UsePlayerKeyboardOptions {
   onVolumeUp: () => void;
   onVolumeDown: () => void;
   onClose?: () => void;
+  onOSD?: (action: { type: string; value?: number; timestamp: number }) => void;
 }
 
 export function usePlayerKeyboard({
@@ -22,6 +23,7 @@ export function usePlayerKeyboard({
   onVolumeUp,
   onVolumeDown,
   onClose,
+  onOSD,
 }: UsePlayerKeyboardOptions) {
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -41,8 +43,10 @@ export function usePlayerKeyboard({
         if (isGenericFocus) {
           e.preventDefault();
           e.stopPropagation();
-          if (video.paused) playerRef.current?.play();
+          const wasPaused = video.paused;
+          if (wasPaused) playerRef.current?.play();
           else playerRef.current?.pause();
+          onOSD?.({ type: wasPaused ? 'play' : 'pause', timestamp: Date.now() });
           return;
         }
       }
@@ -67,16 +71,24 @@ export function usePlayerKeyboard({
 
         switch (e.key) {
           case 'ArrowLeft':
-            if (!isLive) playerRef.current?.seek(Math.max(0, video.currentTime - 10));
+            if (!isLive) {
+              playerRef.current?.seek(Math.max(0, video.currentTime - 10));
+              onOSD?.({ type: 'seek-back', timestamp: Date.now() });
+            }
             break;
           case 'ArrowRight':
-            if (!isLive) playerRef.current?.seek(video.currentTime + 10);
+            if (!isLive) {
+              playerRef.current?.seek(video.currentTime + 10);
+              onOSD?.({ type: 'seek-forward', timestamp: Date.now() });
+            }
             break;
           case 'ArrowUp':
             onVolumeUp();
+            onOSD?.({ type: 'volume', timestamp: Date.now() });
             break;
           case 'ArrowDown':
             onVolumeDown();
+            onOSD?.({ type: 'volume', timestamp: Date.now() });
             break;
         }
         return;
@@ -84,19 +96,25 @@ export function usePlayerKeyboard({
 
       switch (e.key) {
         case ' ':
-        case 'k':
+        case 'k': {
           e.preventDefault();
-          if (video.paused) playerRef.current?.play();
+          const wasPaused = video.paused;
+          if (wasPaused) playerRef.current?.play();
           else playerRef.current?.pause();
+          onOSD?.({ type: wasPaused ? 'play' : 'pause', timestamp: Date.now() });
           break;
+        }
         case 'f':
           e.preventDefault();
           playerRef.current?.toggleFullscreen();
           break;
-        case 'm':
+        case 'm': {
           e.preventDefault();
+          const wasMuted = video.muted;
           onMuteToggle();
+          onOSD?.({ type: wasMuted ? 'unmute' : 'mute', timestamp: Date.now() });
           break;
+        }
         case 'n':
           if (onNext) { e.preventDefault(); onNext(); }
           break;
@@ -120,5 +138,5 @@ export function usePlayerKeyboard({
     // We use capture phase so we can stopPropagation before LRUD gets it
     window.addEventListener('keydown', handleKeyDown, { capture: true });
     return () => window.removeEventListener('keydown', handleKeyDown, { capture: true });
-  }, [playerRef, isLive, onNext, onPrev, onMuteToggle, onVolumeUp, onVolumeDown, onClose]);
+  }, [playerRef, isLive, onNext, onPrev, onMuteToggle, onVolumeUp, onVolumeDown, onClose, onOSD]);
 }

--- a/src/shared/components/ContentCard.tsx
+++ b/src/shared/components/ContentCard.tsx
@@ -10,6 +10,7 @@ interface ContentCardProps {
   progress?: number; // 0-100
   isFavorite?: boolean;
   onFavoriteToggle?: () => void;
+  onRemove?: () => void;
   onClick?: () => void;
   aspectRatio?: 'poster' | 'landscape' | 'square';
   focusKey?: string;
@@ -42,6 +43,27 @@ function FocusableFavoriteButton({ isFavorite, onToggle, focusId }: { isFavorite
   );
 }
 
+function FocusableRemoveButton({ onRemove, focusId }: { onRemove: () => void; focusId: string }) {
+  const { ref, showFocusRing, focusProps } = useSpatialFocusable({
+    focusKey: focusId,
+    onEnterPress: () => onRemove(),
+  });
+
+  return (
+    <button
+      ref={ref}
+      {...focusProps}
+      onClick={(e) => { e.stopPropagation(); onRemove(); }}
+      className={`absolute top-2 right-2 p-1 rounded-full bg-obsidian/60 backdrop-blur-sm hover:bg-error/80 transition-all ${showFocusRing ? 'ring-2 ring-error z-10 bg-error/80' : ''}`}
+      aria-label="Remove"
+    >
+      <svg className="w-3.5 h-3.5 text-text-muted hover:text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  );
+}
+
 const aspectClasses = {
   poster: 'aspect-[2/3]',
   landscape: 'aspect-video',
@@ -56,6 +78,7 @@ export function ContentCard({
   progress,
   isFavorite,
   onFavoriteToggle,
+  onRemove,
   onClick,
   aspectRatio = 'poster',
   focusKey: propFocusKey,
@@ -71,7 +94,7 @@ export function ContentCard({
     onEnterPress,
     onFocus: (layout) => {
       // Auto-scroll into view when focused via D-pad
-      layout.node?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+      layout.node?.scrollIntoView({ behavior: 'instant', block: 'nearest', inline: 'nearest' });
     },
   });
 
@@ -106,6 +129,11 @@ export function ContentCard({
         {/* Favorite star */}
         {onFavoriteToggle && (
           <FocusableFavoriteButton isFavorite={isFavorite} onToggle={onFavoriteToggle} focusId={`fav-btn-${cardKey}`} />
+        )}
+
+        {/* Remove button (for Continue Watching) */}
+        {onRemove && (
+          <FocusableRemoveButton onRemove={onRemove} focusId={`remove-btn-${cardKey}`} />
         )}
 
         {/* Progress bar */}

--- a/src/shared/components/ContentRail.tsx
+++ b/src/shared/components/ContentRail.tsx
@@ -1,11 +1,11 @@
 import { createContext, useRef, type ReactNode } from 'react';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import { useSpatialFocusable, useSpatialContainer, FocusContext } from '@shared/hooks/useSpatialNav';
 import { HorizontalScroll } from './HorizontalScroll';
 
 const RailContext = createContext<string>('SN:ROOT');
 
-function FocusableSeeAll({ to, parentFocusKey }: { to: string; parentFocusKey: string }) {
+function FocusableSeeAllCard({ to, parentFocusKey }: { to: string; parentFocusKey: string }) {
   const navigate = useNavigate();
 
   const { ref, showFocusRing, focusProps } = useSpatialFocusable({
@@ -17,16 +17,27 @@ function FocusableSeeAll({ to, parentFocusKey }: { to: string; parentFocusKey: s
   });
 
   return (
-    <div ref={ref} {...focusProps}>
-      <Link
+    <div className="rail-item flex-shrink-0">
+      <div
+        ref={ref}
+        {...focusProps}
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic route path from props
-        to={to as any}
-        className={`text-sm text-teal hover:text-teal/80 transition-colors whitespace-nowrap min-h-[44px] flex items-center ${
-          showFocusRing ? 'ring-2 ring-teal/50 rounded px-2' : ''
+        onClick={() => navigate({ to: to as any })}
+        className={`flex items-center justify-center aspect-[2/3] rounded-lg border cursor-pointer transition-all duration-200 ${
+          showFocusRing
+            ? 'border-teal bg-teal/10 scale-[1.08] ring-2 ring-teal/60 ring-offset-2 ring-offset-obsidian shadow-[0_0_24px_rgba(45,212,191,0.3)]'
+            : 'border-border-subtle bg-surface-raised/50 hover:border-teal/30 hover:bg-surface-raised'
         }`}
       >
-        See All →
-      </Link>
+        <div className="text-center px-2">
+          <svg className={`w-6 h-6 mx-auto mb-2 ${showFocusRing ? 'text-teal' : 'text-text-muted'}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+          <span className={`text-xs font-medium ${showFocusRing ? 'text-teal' : 'text-text-muted'}`}>
+            See All
+          </span>
+        </div>
+      </div>
     </div>
   );
 }
@@ -42,13 +53,26 @@ interface ContentRailProps {
   focusKey?: string;
 }
 
-export function ContentRail({
+/**
+ * ContentRail — early-returns BEFORE mounting the inner component
+ * to avoid the norigin conditional render anti-pattern
+ * (calling useFocusable then returning null registers a ghost node).
+ */
+export function ContentRail(props: ContentRailProps) {
+  const { isEmpty = false, isLoading = false } = props;
+
+  // Return null BEFORE any hooks are called — prevents ghost focus nodes
+  if (isEmpty && !isLoading) return null;
+
+  return <ContentRailInner {...props} />;
+}
+
+/** Inner component — only mounts when rail has content or is loading */
+function ContentRailInner({
   title,
   seeAllTo,
   children,
   className = '',
-  emptyMessage: _emptyMessage = 'Nothing here yet',
-  isEmpty = false,
   isLoading = false,
   focusKey: propFocusKey,
 }: ContentRailProps) {
@@ -62,8 +86,6 @@ export function ContentRail({
     focusBoundaryDirections: ['left', 'right'],
   });
 
-  if (isEmpty && !isLoading) return null;
-
   return (
     <FocusContext.Provider value={focusKey}>
       <section ref={ref} className={`${className}`}>
@@ -71,9 +93,6 @@ export function ContentRail({
           <h2 className="font-display text-lg lg:text-xl font-semibold text-text-primary">
             {title}
           </h2>
-          {seeAllTo && (
-            <FocusableSeeAll to={seeAllTo} parentFocusKey={railId} />
-          )}
         </div>
 
         <div className="px-6 lg:px-10">
@@ -91,6 +110,9 @@ export function ContentRail({
             <HorizontalScroll ref={scrollRef}>
               <RailContext.Provider value={focusKey}>
                 {children}
+                {seeAllTo && (
+                  <FocusableSeeAllCard to={seeAllTo} parentFocusKey={railId} />
+                )}
               </RailContext.Provider>
             </HorizontalScroll>
           )}

--- a/src/shared/components/FocusableCard.tsx
+++ b/src/shared/components/FocusableCard.tsx
@@ -10,6 +10,7 @@ interface FocusableCardProps {
   isFavorite?: boolean;
   isNew?: boolean;
   onFavoriteToggle?: () => void;
+  onRemove?: () => void;
   onClick?: () => void;
   aspectRatio?: 'poster' | 'landscape' | 'square';
   /** Unique spatial focus key — prevents ID collisions when titles match */
@@ -25,6 +26,7 @@ export function FocusableCard({
   isFavorite,
   isNew,
   onFavoriteToggle,
+  onRemove,
   onClick,
   aspectRatio = 'poster',
   focusKey,
@@ -46,6 +48,7 @@ export function FocusableCard({
         progress={progress}
         isFavorite={isFavorite}
         onFavoriteToggle={onFavoriteToggle}
+        onRemove={onRemove}
         onClick={onClick}
         aspectRatio={aspectRatio}
       />

--- a/src/shared/components/TopNav.tsx
+++ b/src/shared/components/TopNav.tsx
@@ -63,15 +63,16 @@ export function TopNav() {
     };
   }, []);
 
-  // TV mode: minimal header with just logo + profile button
+  // TV mode: full nav header with Home, language links, Search, and profile
   if (isTVMode) {
     return (
       <FocusContext.Provider value={topNavFocusKey}>
         <header ref={topNavRef} className="fixed top-0 left-0 right-0 z-50 bg-obsidian/95 backdrop-blur-sm">
-          <nav className="flex items-center justify-between h-12 px-4 lg:px-10">
-            <Link to="/" className="font-display text-lg font-bold text-text-primary">
+          <nav className="flex items-center h-12 px-4 lg:px-10 gap-2">
+            <Link to="/" className="font-display text-lg font-bold text-text-primary flex-shrink-0">
               Stream<span className="text-teal">Vault</span>
             </Link>
+            <TopNavFocusGroup languages={languages} matchRoute={matchRoute} />
             <ProfileMenu
               username={username}
               profileOpen={profileOpen}

--- a/src/shared/providers/SpatialNavProvider.tsx
+++ b/src/shared/providers/SpatialNavProvider.tsx
@@ -45,6 +45,10 @@ export function SpatialNavProvider({ children }: SpatialNavProviderProps) {
       // When suppressArrowNav is true (player active in TV mode), skip arrow handling
       if (isArrow && useUIStore.getState().suppressArrowNav) return;
 
+      if (isArrow) {
+        e.preventDefault();  // Prevent native scroll — norigin handles focus movement, card onFocus scrolls into view
+      }
+
       const isNavKey = isArrow || ['Enter', 'Escape', 'Backspace'].includes(e.key);
 
       if (isNavKey) {


### PR DESCRIPTION
## Summary
- **Critical**: `preventDefault()` on arrow keys stops browser scroll from stealing focus — fixes D-pad not moving between rails (Issues 4, 6, 8)
- **Critical**: ContentRail refactored to inner component pattern — prevents norigin ghost focus nodes when rails empty
- **Navigation**: Initial focus waits for data load, `scrollIntoView` changed to instant to prevent jank (Issue 9)
- **TV Nav**: Header now includes Home, language links (Telugu/Hindi), Search — all D-pad accessible (Issue 5)
- **See All**: Moved from title bar to end of card row as a card-like element (Issue 7)
- **Player OSD**: New overlay shows seek ±10s, volume bar, play/pause icons on keyboard actions (Issue 3)
- **Continue Watching**: X button on cards to remove individual items (Issue 2, requires backend PR)
- **Layout**: Live TV cards changed from square to landscape for consistency (Issue 1)

## Dependencies
- Backend PR: srinivas-kotha/streamvault-backend (fix/history-delete-endpoint) — DELETE /api/history/:contentId

## Test plan
- [ ] D-pad Down from any rail moves focus to next rail card (not scroll)
- [ ] On page load, first card auto-focused with visible ring after data loads
- [ ] TV mode header: Home, Telugu, Hindi, Search all navigable
- [ ] See All card appears at end of each rail, reachable via D-pad Right
- [ ] Player: Left/Right shows seek OSD, Up/Down shows volume, Enter shows play/pause
- [ ] Continue Watching: X button appears, removes item on press
- [ ] Live TV tab: cards use landscape aspect consistently
- [ ] After removing all Continue Watching items, no ghost focus issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)