### PR TITLE
debug: spatial nav diagnostic overlay

### DIFF
--- a/src/shared/providers/SpatialNavProvider.tsx
+++ b/src/shared/providers/SpatialNavProvider.tsx
@@ -119,7 +119,6 @@ function SpatialDebugOverlay() {
     function update() {
       const focusKey = getCurrentFocusKey() || 'none';
       const focusedEls = document.querySelectorAll('[data-focused="true"]');
-      const allFocusable = document.querySelectorAll('[tabindex]');
       setInfo((prev) => ({
         ...prev,
         focusKey,


### PR DESCRIPTION
## Summary
- Adds `?debug=spatial` URL param to enable norigin-spatial-navigation debug mode
- Shows visible overlay with: current focus key, last keypress, data-focused element count
- Enables norigin's built-in `visualDebug` (draws colored borders around all focusable elements)
- Console logs arrow key events with current focus state

**Temporary PR — merge to diagnose D-pad navigation issue, then revert.**

## Test plan
- [ ] Open `https://streamvault.srinivaskotha.uk?debug=spatial`
- [ ] Check if overlay shows at bottom-right
- [ ] Press arrow keys — does focus key change? Does data-focused count go from 0 to 1?
- [ ] Check browser console for `[spatial]` logs
- [ ] Look at norigin's visual debug borders (colored outlines on focusable elements)

Generated with Claude Code