### PR TITLE
fix: limit desktop nav to 9 languages, fix search input Enter-to-type

### DIFF
--- a/src/features/language/components/LiveTabContent.tsx
+++ b/src/features/language/components/LiveTabContent.tsx
@@ -39,7 +39,9 @@ function FocusableSearchInput({ value, onChange, placeholder, focusKey }: { valu
   const inputRef = useRef<HTMLInputElement>(null);
   const { ref, showFocusRing, focusProps } = useSpatialFocusable({
     focusKey,
-    onEnterPress: () => inputRef.current?.focus(),
+    onEnterPress: () => {
+      setTimeout(() => inputRef.current?.focus(), 0);
+    },
   });
 
   return (
@@ -53,6 +55,9 @@ function FocusableSearchInput({ value, onChange, placeholder, focusKey }: { valu
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') inputRef.current?.blur();
+        }}
         className="w-full pl-10 pr-4 py-2.5 bg-surface-raised border border-border rounded-lg text-text-primary placeholder:text-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-teal/50 focus:border-teal-dim transition-all"
       />
       {value && (

--- a/src/features/language/components/MoviesTabContent.tsx
+++ b/src/features/language/components/MoviesTabContent.tsx
@@ -94,7 +94,10 @@ function FocusableSearchInput({ value, onChange, placeholder, focusKey }: { valu
   const inputRef = useRef<HTMLInputElement>(null);
   const { ref, showFocusRing, focusProps } = useSpatialFocusable({
     focusKey,
-    onEnterPress: () => inputRef.current?.focus(),
+    onEnterPress: () => {
+      // Delay to ensure norigin finishes processing before we steal DOM focus
+      setTimeout(() => inputRef.current?.focus(), 0);
+    },
   });
 
   return (
@@ -108,6 +111,12 @@ function FocusableSearchInput({ value, onChange, placeholder, focusKey }: { valu
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          // Escape blurs back to spatial nav
+          if (e.key === 'Escape') {
+            inputRef.current?.blur();
+          }
+        }}
         className="w-full pl-10 pr-4 py-2.5 bg-surface-raised border border-border rounded-lg text-text-primary placeholder:text-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-teal/50 focus:border-teal-dim transition-all"
       />
       {value && (

--- a/src/features/language/components/SeriesTabContent.tsx
+++ b/src/features/language/components/SeriesTabContent.tsx
@@ -92,7 +92,9 @@ function FocusableSearchInput({ value, onChange, placeholder, focusKey }: { valu
   const inputRef = useRef<HTMLInputElement>(null);
   const { ref, showFocusRing, focusProps } = useSpatialFocusable({
     focusKey,
-    onEnterPress: () => inputRef.current?.focus(),
+    onEnterPress: () => {
+      setTimeout(() => inputRef.current?.focus(), 0);
+    },
   });
 
   return (
@@ -106,6 +108,9 @@ function FocusableSearchInput({ value, onChange, placeholder, focusKey }: { valu
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') inputRef.current?.blur();
+        }}
         className="w-full pl-10 pr-4 py-2.5 bg-surface-raised border border-border rounded-lg text-text-primary placeholder:text-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-teal/50 focus:border-teal-dim transition-all"
       />
       {value && (

--- a/src/shared/components/TopNav.tsx
+++ b/src/shared/components/TopNav.tsx
@@ -126,7 +126,7 @@ export function TopNav() {
 
           {/* Desktop Nav Items */}
           <div className="hidden md:flex flex-1 items-center overflow-x-auto scrollbar-hide">
-            <TopNavFocusGroup languages={languages} matchRoute={matchRoute} />
+            <TopNavFocusGroup languages={languages.slice(0, 9)} matchRoute={matchRoute} />
           </div>
 
           {/* Profile */}


### PR DESCRIPTION
## Summary
- Desktop nav was showing ALL detected languages (only TV mode had `.slice(0, 9)`) — now both modes show max 9
- Search inputs on language tabs (Movies, Series, Live TV) use `setTimeout(0)` in `onEnterPress` so norigin finishes event processing before DOM focus is transferred to the `<input>`
- Added `Escape` key handler on search inputs to blur back to spatial navigation

## Test plan
- [ ] Desktop: top nav shows max 9 languages (Home + 9 languages + Search)
- [ ] Keyboard: navigate to search input, press Enter — cursor should appear and typing should work
- [ ] Keyboard: while typing in search, press Escape — should blur input and return to spatial nav
- [ ] Verify on Movies, Series, and Live TV tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)