### PR TITLE
fix: nav containers non-focusable to unblock Up navigation from cards

### DIFF
--- a/src/shared/components/TopNav.tsx
+++ b/src/shared/components/TopNav.tsx
@@ -16,9 +16,11 @@ export function TopNav() {
   const [scrolled, setScrolled] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
 
-  // Register the top-nav spatial container
+  // Register the top-nav spatial container — focusable: false so individual
+  // NavItems are direct smartNavigate candidates (containers block Up navigation)
   const { ref: topNavRef, focusKey: topNavFocusKey } = useSpatialContainer({
     focusKey: 'top-nav',
+    focusable: false,
   });
 
   // Detect languages from categories
@@ -213,6 +215,7 @@ function TopNavFocusGroup({ languages, matchRoute }: { languages: string[]; matc
 
   const { ref: groupRef, focusKey } = useSpatialContainer({
     focusKey: 'top-nav-items',
+    focusable: false,
   });
 
   return (


### PR DESCRIPTION
## Summary
- `top-nav` and `top-nav-items` containers changed to `focusable: false`
- Individual `NavItem` elements remain `focusable: true` (via `useSpatialFocusable`)
- This fixes Up-arrow from content cards being stuck — norigin was picking the container's large bounding rect instead of the individual nav links

## Root cause
norigin's `smartNavigate` considers all `focusable: true` elements as candidates. Container elements with `focusable: true` have large bounding rects spanning the full nav bar width. When computing distance from a card to the nav bar, the container would win but then delegate to a child that might not satisfy the directional check, causing the move to be rejected. With containers at `focusable: false`, only the leaf NavItem elements participate in distance calculation.

## Test plan
- [ ] Press Up from Continue Watching cards — focus should move to Home/Telugu/Hindi in the nav bar
- [ ] Press Down from nav bar — focus should return to content cards
- [ ] Left/Right within nav bar — should cycle through language links
- [ ] Verify with `?debug=spatial` — no "bootstrapping to SN:ROOT" loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)