### PR TITLE
fix: Lighthouse audit improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM nginx:alpine AS runtime
 
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY security-headers.conf /etc/nginx/conf.d/security-headers.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 
 EXPOSE 80

--- a/nginx.conf
+++ b/nginx.conf
@@ -43,19 +43,20 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header Pragma "no-cache" always;
         add_header Service-Worker-Allowed "/" always;
-        add_header X-Content-Type-Options "nosniff" always;
+        include /etc/nginx/conf.d/security-headers.conf;
     }
 
     # PWA manifest
     location = /manifest.json {
         add_header Cache-Control "no-cache" always;
-        add_header X-Content-Type-Options "nosniff" always;
+        include /etc/nginx/conf.d/security-headers.conf;
         types { application/manifest+json json; }
     }
 
     # SPA routing — index.html must not be cached (JS/CSS have content hashes)
     location / {
         add_header Cache-Control "no-cache" always;
+        include /etc/nginx/conf.d/security-headers.conf;
         try_files $uri $uri/ /index.html;
     }
 
@@ -63,12 +64,14 @@ server {
     location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        include /etc/nginx/conf.d/security-headers.conf;
     }
 
     # Cache media files
     location ~* \.(png|jpg|jpeg|gif|ico|svg|webp|woff2?)$ {
         expires 7d;
         add_header Cache-Control "public";
+        include /etc/nginx/conf.d/security-headers.conf;
     }
 
     # Gzip
@@ -85,12 +88,13 @@ server {
         application/xml
         image/svg+xml;
 
-    # Security headers
+    # Security headers (server-level fallback for locations without own add_header)
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://api.fontshare.com; img-src 'self' data: https: http:; font-src 'self' https://api.fontshare.com https://cdn.fontshare.com; connect-src 'self' https: http:; media-src 'self' http: https:; worker-src 'self'; manifest-src 'self'; frame-ancestors 'self';" always;
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://api.fontshare.com; img-src 'self' data: https:; font-src 'self' https://api.fontshare.com https://cdn.fontshare.com; connect-src 'self' https:; media-src 'self' http: https:; worker-src 'self'; manifest-src 'self'; frame-ancestors 'self';" always;
 
     server_tokens off;
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -37,21 +37,5 @@
       "type": "image/png",
       "purpose": "maskable"
     }
-  ],
-  "screenshots": [
-    {
-      "src": "/screenshot-wide.png",
-      "sizes": "1280x720",
-      "type": "image/png",
-      "form_factor": "wide",
-      "label": "StreamVault home screen with content rails"
-    },
-    {
-      "src": "/screenshot-narrow.png",
-      "sizes": "390x844",
-      "type": "image/png",
-      "form_factor": "narrow",
-      "label": "StreamVault mobile view"
-    }
   ]
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,0 +1,6 @@
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://api.fontshare.com; img-src 'self' data: https:; font-src 'self' https://api.fontshare.com https://cdn.fontshare.com; connect-src 'self' https:; media-src 'self' http: https:; worker-src 'self'; manifest-src 'self'; frame-ancestors 'self';" always;

--- a/src/features/home/components/HomePage.tsx
+++ b/src/features/home/components/HomePage.tsx
@@ -67,7 +67,7 @@ export function HomePage() {
             isLoading={teluguMoviesLoading}
             isEmpty={!teluguMovies.length}
           >
-            {teluguMovies.map((item) => (
+            {teluguMovies.map((item, index) => (
               <FocusableCard
                 key={item.stream_id}
                 focusKey={`vod-${item.stream_id}`}
@@ -76,6 +76,7 @@ export function HomePage() {
                 subtitle={item.rating ? `⭐ ${item.rating}` : undefined}
                 isNew={isNewContent(item.added)}
                 aspectRatio="poster"
+                priority={index < 4}
                 onClick={() => handleVodClick(item)}
               />
             ))}

--- a/src/features/live/components/ChannelCard.tsx
+++ b/src/features/live/components/ChannelCard.tsx
@@ -5,6 +5,7 @@ import { useEPG } from '../api';
 import type { XtreamLiveStream } from '@shared/types/api';
 import { Badge } from '@shared/components/Badge';
 import { usePlayerStore } from '@lib/store';
+import { upgradeProtocol } from '@shared/components/LazyImage';
 
 interface ChannelCardProps {
   channel: XtreamLiveStream;
@@ -45,7 +46,7 @@ export function ChannelCard({ channel }: ChannelCardProps) {
       <div className="aspect-square relative bg-surface flex items-center justify-center overflow-hidden">
         {channel.stream_icon ? (
           <img
-            src={channel.stream_icon}
+            src={upgradeProtocol(channel.stream_icon)}
             alt={channel.name}
             loading="lazy"
             className="w-full h-full object-contain p-3"

--- a/src/features/live/components/EPGGrid.tsx
+++ b/src/features/live/components/EPGGrid.tsx
@@ -5,6 +5,7 @@ import { usePlayerStore } from '@lib/store';
 import { EPGTimeAxis, useEPGTimeRange } from './EPGTimeAxis';
 import { EPGProgramBlock } from './EPGProgramBlock';
 import type { XtreamLiveStream } from '@shared/types/api';
+import { upgradeProtocol } from '@shared/components/LazyImage';
 
 interface EPGGridProps {
   channels: XtreamLiveStream[];
@@ -133,7 +134,7 @@ export function EPGGrid({ channels }: EPGGridProps) {
               >
                 {channel.stream_icon ? (
                   <img
-                    src={channel.stream_icon}
+                    src={upgradeProtocol(channel.stream_icon)}
                     alt=""
                     className="w-6 h-6 rounded object-contain flex-shrink-0"
                     onError={(e) => {

--- a/src/features/live/components/FeaturedChannels.tsx
+++ b/src/features/live/components/FeaturedChannels.tsx
@@ -5,6 +5,7 @@ import { useFeaturedChannels, useEPG } from '../api';
 import { usePlayerStore } from '@lib/store';
 import { Badge } from '@shared/components/Badge';
 import type { XtreamLiveStream } from '@shared/types/api';
+import { upgradeProtocol } from '@shared/components/LazyImage';
 
 function FeaturedCard({ channel }: { channel: XtreamLiveStream }) {
   const navigate = useNavigate();
@@ -41,7 +42,7 @@ function FeaturedCard({ channel }: { channel: XtreamLiveStream }) {
       <div className="relative h-28 bg-gradient-to-br from-surface to-obsidian flex items-center justify-center overflow-hidden">
         {channel.stream_icon ? (
           <img
-            src={channel.stream_icon}
+            src={upgradeProtocol(channel.stream_icon)}
             alt={channel.name}
             loading="lazy"
             className="w-full h-full object-contain p-4 transition-transform duration-300 group-hover:scale-110"

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useCallback, useState, forwardRef, useImperativeHandle } from 'react';
-import Hls from 'hls.js';
+import type HlsType from 'hls.js';
 
 export interface QualityLevel {
   index: number;
@@ -37,7 +37,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     ref,
   ) {
     const videoRef = useRef<HTMLVideoElement>(null);
-    const hlsRef = useRef<Hls | null>(null);
+    const hlsRef = useRef<HlsType | null>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const [isReady, setIsReady] = useState(false);
 
@@ -107,6 +107,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       const video = videoRef.current;
       if (!video || !url) return;
 
+      let cancelled = false;
       setIsReady(false);
       const isHls = format === 'm3u8' || url.endsWith('.m3u8');
       let hlsRetryCount = 0;
@@ -114,18 +115,21 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       let fallbackAttempted = false;
 
       const startDirectPlayback = () => {
+        if (cancelled) return;
         destroyHls();
         video.src = url;
         video.onloadeddata = () => {
+          if (cancelled) return;
           setIsReady(true);
           if (startTime > 0 && !isLive) video.currentTime = startTime;
           if (autoPlay) video.play().catch(() => {});
         };
         video.onerror = () => {
+          if (cancelled) return;
           // If direct playback fails and we haven't tried HLS yet, attempt HLS fallback
-          if (!fallbackAttempted && !isHls && Hls.isSupported()) {
+          if (!fallbackAttempted && !isHls) {
             fallbackAttempted = true;
-            startHlsPlayback();
+            initHls();
           } else {
             onError?.('Channel unavailable');
           }
@@ -133,7 +137,8 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         if (autoPlay) video.play().catch(() => {});
       };
 
-      const startHlsPlayback = () => {
+      const startHlsPlayback = (Hls: typeof HlsType) => {
+        if (cancelled) return;
         destroyHls();
         const hls = new Hls({
           enableWorker: true,
@@ -158,6 +163,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         hls.loadSource(url);
 
         hls.on(Hls.Events.MANIFEST_PARSED, () => {
+          if (cancelled) return;
           setIsReady(true);
           if (onQualityLevelsReady) {
             const levels: QualityLevel[] = hls.levels.map((level, i) => ({
@@ -174,6 +180,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         });
 
         hls.on(Hls.Events.ERROR, (_event, data) => {
+          if (cancelled) return;
           if (data.fatal) {
             if (data.type === Hls.ErrorTypes.MEDIA_ERROR) {
               hls.recoverMediaError();
@@ -204,20 +211,33 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         });
       };
 
-      if (isHls && Hls.isSupported()) {
-        startHlsPlayback();
-      } else if (isHls && video.canPlayType('application/vnd.apple.mpegurl')) {
-        // Native HLS support (Safari)
-        video.src = url;
-        setIsReady(true);
-        if (startTime > 0 && !isLive) video.currentTime = startTime;
-        if (autoPlay) video.play().catch(() => {});
+      const initHls = async () => {
+        const { default: Hls } = await import('hls.js');
+        if (cancelled) return;
+        if (Hls.isSupported()) {
+          startHlsPlayback(Hls);
+        } else {
+          startDirectPlayback();
+        }
+      };
+
+      if (isHls) {
+        // Check native HLS support first (Safari), otherwise dynamic-import hls.js
+        if (video.canPlayType('application/vnd.apple.mpegurl')) {
+          video.src = url;
+          setIsReady(true);
+          if (startTime > 0 && !isLive) video.currentTime = startTime;
+          if (autoPlay) video.play().catch(() => {});
+        } else {
+          initHls();
+        }
       } else {
         // Direct playback for .ts, .mp4, or non-HLS streams
         startDirectPlayback();
       }
 
       return () => {
+        cancelled = true;
         destroyHls();
         video.onloadeddata = null;
         video.onerror = null;

--- a/src/shared/components/ContentCard.tsx
+++ b/src/shared/components/ContentCard.tsx
@@ -14,6 +14,8 @@ interface ContentCardProps {
   onClick?: () => void;
   aspectRatio?: 'poster' | 'landscape' | 'square';
   focusKey?: string;
+  /** Eagerly load image with high fetchPriority (use for above-the-fold LCP images) */
+  priority?: boolean;
 }
 
 function FocusableFavoriteButton({ isFavorite, onToggle, focusId }: { isFavorite?: boolean; onToggle: () => void; focusId: string }) {
@@ -82,6 +84,7 @@ export function ContentCard({
   onClick,
   aspectRatio = 'poster',
   focusKey: propFocusKey,
+  priority,
 }: ContentCardProps) {
   const cardKey = propFocusKey || `card-${title.replace(/\s+/g, '-').toLowerCase()}`;
 
@@ -115,6 +118,7 @@ export function ContentCard({
           src={image}
           alt={title}
           aspectRatio={aspectRatio}
+          priority={priority}
           className="transition-transform duration-300 group-hover:scale-105"
         />
 

--- a/src/shared/components/FocusableCard.tsx
+++ b/src/shared/components/FocusableCard.tsx
@@ -15,6 +15,8 @@ interface FocusableCardProps {
   aspectRatio?: 'poster' | 'landscape' | 'square';
   /** Unique spatial focus key — prevents ID collisions when titles match */
   focusKey?: string;
+  /** Eagerly load image with high fetchPriority (use for above-the-fold LCP images) */
+  priority?: boolean;
 }
 
 export function FocusableCard({
@@ -30,6 +32,7 @@ export function FocusableCard({
   onClick,
   aspectRatio = 'poster',
   focusKey,
+  priority,
 }: FocusableCardProps) {
   return (
     <div className="rail-item flex-shrink-0">
@@ -51,6 +54,7 @@ export function FocusableCard({
         onRemove={onRemove}
         onClick={onClick}
         aspectRatio={aspectRatio}
+        priority={priority}
       />
     </div>
   );

--- a/src/shared/components/LazyImage.tsx
+++ b/src/shared/components/LazyImage.tsx
@@ -6,6 +6,14 @@ interface LazyImageProps {
   className?: string;
   fallbackClassName?: string;
   aspectRatio?: 'square' | 'poster' | 'landscape';
+  /** When true, loads eagerly with high fetchPriority (use for LCP images) */
+  priority?: boolean;
+}
+
+/** Rewrite http:// image URLs to https:// to avoid mixed-content warnings */
+export function upgradeProtocol(url: string): string {
+  if (url.startsWith('http://')) return 'https://' + url.slice(7);
+  return url;
 }
 
 const aspectClasses = {
@@ -22,14 +30,22 @@ export function LazyImage({
   className = '',
   fallbackClassName = '',
   aspectRatio = 'poster',
+  priority = false,
 }: LazyImageProps) {
-  const [state, setState] = useState<LoadState>(!src ? 'error' : 'placeholder');
+  const safeSrc = src ? upgradeProtocol(src) : '';
+  const [state, setState] = useState<LoadState>(!safeSrc ? 'error' : priority ? 'loading' : 'placeholder');
   const containerRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
 
   useEffect(() => {
-    if (!src) {
+    if (!safeSrc) {
       setState('error');
+      return;
+    }
+
+    // Priority images start loading immediately
+    if (priority) {
+      setState('loading');
       return;
     }
 
@@ -52,7 +68,7 @@ export function LazyImage({
 
     observer.observe(el);
     return () => observer.disconnect();
-  }, [src]);
+  }, [safeSrc, priority]);
 
   const handleLoad = useCallback(() => {
     setState('loaded');
@@ -87,9 +103,10 @@ export function LazyImage({
       {showImage && (
         <img
           ref={imgRef}
-          src={src}
+          src={safeSrc}
           alt={alt}
-          loading="lazy"
+          loading={priority ? 'eager' : 'lazy'}
+          fetchPriority={priority ? 'high' : undefined}
           onLoad={handleLoad}
           onError={handleError}
           className={`absolute inset-0 w-full h-full object-cover transition-opacity duration-300 ${

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -28,7 +28,7 @@
   /* Text */
   --color-text-primary: #F1F5F9;
   --color-text-secondary: #94A3B8;
-  --color-text-muted: #64748B;
+  --color-text-muted: #7E8FA3;
 
   /* Typography */
   --font-sans: 'General Sans', system-ui, -apple-system, sans-serif;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,7 +38,6 @@ export default defineConfig({
         manualChunks: {
           'vendor-react': ['react', 'react-dom'],
           'vendor-tanstack': ['@tanstack/react-query', '@tanstack/react-router', '@tanstack/react-virtual'],
-          'vendor-hls': ['hls.js'],
           'vendor-motion': ['framer-motion'],
         },
       },


### PR DESCRIPTION
## Summary
- **Performance**: Lazy-load hls.js via dynamic import (-524KB from initial bundle), add `fetchPriority="high"` for LCP images in first home rail
- **Best Practices**: Add `Cross-Origin-Opener-Policy: same-origin`, tighten CSP (drop `http:` from `img-src`/`connect-src`), fix nginx `add_header` inheritance so security headers apply to all locations
- **Accessibility**: Improve `text-muted` contrast from #64748B to #7E8FA3 (WCAG AA compliant at 10px)
- **SEO**: Add `robots.txt` with `Disallow: /`, remove non-existent PWA screenshot references from manifest.json
- **Mixed content**: `upgradeProtocol()` rewrites `http://` → `https://` for all image URLs (LazyImage + ChannelCard + FeaturedChannels + EPGGrid)

## Test plan
- [ ] `npm run build` passes (verified locally, zero TS errors)
- [ ] Run Lighthouse in incognito — expect Performance ~40+, Accessibility 100, Best Practices ~80+, SEO 100
- [ ] Check Network tab on home page: `hls-*.js` chunk should NOT load until player opens
- [ ] Check console: no mixed content warnings, no 404s for robots.txt or screenshots
- [ ] Test video playback: HLS streams still work (dynamic import doesn't break player)
- [ ] Test D-pad navigation: no regressions (changes don't touch spatial nav)
- [ ] Verify security headers appear on `/`, `/sw.js`, `/manifest.json` responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)