### PR TITLE
fix: make all spatial containers focusable:false for D-pad navigation

### DIFF
--- a/src/features/auth/components/LoginPage.tsx
+++ b/src/features/auth/components/LoginPage.tsx
@@ -98,7 +98,7 @@ export function LoginPage() {
 
   usePageFocus('username-input');
 
-  const { ref: formRef, focusKey } = useSpatialContainer({ focusKey: 'login-form' });
+  const { ref: formRef, focusKey } = useSpatialContainer({ focusKey: 'login-form', focusable: false });
 
   const onSubmit = (data: LoginForm) => {
     loginMutation.mutate(data);

--- a/src/features/live/components/FeaturedChannels.tsx
+++ b/src/features/live/components/FeaturedChannels.tsx
@@ -101,6 +101,7 @@ export function FeaturedChannels() {
   // Register container for featured channel cards
   const { ref: containerRef, focusKey } = useSpatialContainer({
     focusKey: 'featured-channels',
+    focusable: false,
   });
 
   if (isLoading) {

--- a/src/features/live/components/LivePage.tsx
+++ b/src/features/live/components/LivePage.tsx
@@ -128,6 +128,7 @@ function FocusableLiveSearch({ searchQuery, setSearchQuery }: {
 function SidebarNav({ categories, activeCatId, isLoading, onSelect }: SidebarNavProps) {
   const { ref, focusKey } = useSpatialContainer({
     focusKey: 'live-sidebar',
+    focusable: false,
     isFocusBoundary: true,
     focusBoundaryDirections: ['left'],
   });
@@ -183,21 +184,25 @@ export function LivePage() {
   // Horizontal split: sidebar | main
   const { ref: layoutRef, focusKey: layoutFocusKey } = useSpatialContainer({
     focusKey: 'live-layout',
+    focusable: false,
   });
 
   // Main content area
   const { ref: mainRef, focusKey: mainFocusKey } = useSpatialContainer({
     focusKey: 'live-main',
+    focusable: false,
   });
 
   // Controls bar (search + view toggles)
-  const { focusKey: controlsFocusKey } = useSpatialContainer({
+  const { ref: controlsRef, focusKey: controlsFocusKey } = useSpatialContainer({
     focusKey: 'live-controls',
+    focusable: false,
   });
 
   // Channel grid container
-  const { focusKey: channelGridFocusKey } = useSpatialContainer({
+  const { ref: channelGridRef, focusKey: channelGridFocusKey } = useSpatialContainer({
     focusKey: 'live-channel-grid',
+    focusable: false,
   });
 
   const { data: categories, isLoading: catLoading } = useLiveCategories();
@@ -272,7 +277,7 @@ export function LivePage() {
         <div ref={mainRef} className="flex-1 min-w-0">
           {/* Top bar: Search + View toggle */}
           <FocusContext.Provider value={controlsFocusKey}>
-          <div className="flex items-center gap-3 mb-4">
+          <div ref={controlsRef} className="flex items-center gap-3 mb-4">
             <FocusableLiveSearch searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
 
             {/* View mode toggle */}
@@ -306,6 +311,7 @@ export function LivePage() {
           </FocusContext.Provider>
 
           <FocusContext.Provider value={channelGridFocusKey}>
+          <div ref={channelGridRef}>
           {streamsLoading ? (
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
               <SkeletonGrid count={18} aspectRatio="square" />
@@ -321,6 +327,7 @@ export function LivePage() {
           ) : (
             <ChannelGrid channels={filteredStreams} />
           )}
+          </div>
           </FocusContext.Provider>
         </div>
         </FocusContext.Provider>

--- a/src/features/player/components/PlayerControls.tsx
+++ b/src/features/player/components/PlayerControls.tsx
@@ -211,6 +211,7 @@ export function PlayerControls({
   // Spatial Navigation: controls container
   const { ref: containerRef, focusKey } = useSpatialContainer({
     focusKey: 'player-controls',
+    focusable: false,
   });
 
   const handleSeek = useCallback(

--- a/src/features/player/components/PlayerPage.tsx
+++ b/src/features/player/components/PlayerPage.tsx
@@ -108,6 +108,7 @@ export function PlayerPage({
   // Spatial Navigation: player container with focus boundary
   const { ref, focusKey, hasFocusedChild } = useSpatialContainer({
     focusKey: 'player-container',
+    focusable: false,
     isFocusBoundary: true,
   });
 

--- a/src/features/search/components/SearchPage.tsx
+++ b/src/features/search/components/SearchPage.tsx
@@ -134,7 +134,7 @@ function FocusablePill({ id, label, isActive, onSelect }: {
 }
 
 function SearchBarContainer({ children }: { children: React.ReactNode }) {
-  const { ref, focusKey } = useSpatialContainer({ focusKey: 'search-bar' });
+  const { ref, focusKey } = useSpatialContainer({ focusKey: 'search-bar', focusable: false });
   return (
     <FocusContext.Provider value={focusKey}>
       <div ref={ref}>{children}</div>
@@ -143,7 +143,7 @@ function SearchBarContainer({ children }: { children: React.ReactNode }) {
 }
 
 function SearchTabsContainer({ children }: { children: React.ReactNode }) {
-  const { ref, focusKey } = useSpatialContainer({ focusKey: 'search-tabs' });
+  const { ref, focusKey } = useSpatialContainer({ focusKey: 'search-tabs', focusable: false });
   return (
     <FocusContext.Provider value={focusKey}>
       <div ref={ref}>{children}</div>
@@ -152,7 +152,7 @@ function SearchTabsContainer({ children }: { children: React.ReactNode }) {
 }
 
 function SearchResultsContainer({ children }: { children: React.ReactNode }) {
-  const { ref, focusKey } = useSpatialContainer({ focusKey: 'search-results' });
+  const { ref, focusKey } = useSpatialContainer({ focusKey: 'search-results', focusable: false });
   return (
     <FocusContext.Provider value={focusKey}>
       <div ref={ref}>{children}</div>

--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -68,6 +68,35 @@ function ResumeButton({ seriesId, episode, seriesName, onResume }: {
   );
 }
 
+/** Extracted so useSpatialFocusable only runs when the button is actually mounted */
+function LoadMoreButton({ seriesId, remaining, onLoadMore }: {
+  seriesId: string;
+  remaining: number;
+  onLoadMore: () => void;
+}) {
+  const { ref, showFocusRing, focusProps } = useSpatialFocusable({
+    focusKey: `series-load-more-${seriesId}`,
+    onEnterPress: onLoadMore,
+  });
+
+  return (
+    <div className="px-6 lg:px-10 mt-4">
+      <button
+        ref={ref}
+        {...focusProps}
+        onClick={onLoadMore}
+        className={`w-full py-3 rounded-xl border text-sm font-medium transition-all ${
+          showFocusRing
+            ? 'bg-surface-raised ring-2 ring-teal ring-offset-2 ring-offset-obsidian text-text-primary'
+            : 'bg-surface-raised border-border text-text-secondary hover:border-teal/20 hover:text-text-primary'
+        }`}
+      >
+        Load More ({remaining} remaining)
+      </button>
+    </div>
+  );
+}
+
 function formatEpisodeDate(unixTimestamp: string): string {
   const ts = parseInt(unixTimestamp, 10);
   if (!ts || isNaN(ts)) return '';
@@ -383,12 +412,14 @@ export function SeriesDetail() {
     focusable: false,
   });
 
-  const { focusKey: actionsFocusKey } = useSpatialContainer({
+  const { ref: actionsRef, focusKey: actionsFocusKey } = useSpatialContainer({
     focusKey: `series-actions-${seriesId}`,
+    focusable: false,
   });
 
-  const { focusKey: episodesFocusKey } = useSpatialContainer({
+  const { ref: episodesRef, focusKey: episodesFocusKey } = useSpatialContainer({
     focusKey: `series-episodes-${seriesId}`,
+    focusable: false,
   });
 
   const { ref: backRef, showFocusRing: backFocusRing, focusProps: backFocusProps } = useSpatialFocusable({
@@ -399,11 +430,6 @@ export function SeriesDetail() {
   const { ref: closeRef, showFocusRing: closeFocusRing, focusProps: closeFocusProps } = useSpatialFocusable({
     focusKey: `series-close-${seriesId}`,
     onEnterPress: () => setPlayingEpisodeId(null),
-  });
-
-  const { ref: loadMoreRef, showFocusRing: loadMoreFocusRing, focusProps: loadMoreFocusProps } = useSpatialFocusable({
-    focusKey: `series-load-more-${seriesId}`,
-    onEnterPress: handleLoadMore,
   });
 
   // Auto-focus resume button or back button when page loads
@@ -449,6 +475,7 @@ export function SeriesDetail() {
       <FocusContext.Provider value={contentFocusKey}>
         <div ref={contentRef} className="pb-12">
           <FocusContext.Provider value={actionsFocusKey}>
+            <div ref={actionsRef}>
             {/* Back button */}
             <div className="px-6 lg:px-10 pt-4 mb-4">
               <button
@@ -565,6 +592,7 @@ export function SeriesDetail() {
                 }}
               />
             )}
+            </div>
           </FocusContext.Provider>
 
           {/* Plot */}
@@ -694,7 +722,10 @@ export function SeriesDetail() {
 
           {/* Episode List */}
           <FocusContext.Provider value={episodesFocusKey}>
-            <div ref={episodeListRef} className="space-y-2 px-6 lg:px-10">
+            <div ref={(el: HTMLDivElement | null) => {
+              (episodesRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+              episodeListRef.current = el;
+            }} className="space-y-2 px-6 lg:px-10">
               {visibleEpisodes.length === 0 && episodeSearch ? (
                 <div className="py-12 text-center">
                   <p className="text-text-muted text-sm">
@@ -718,22 +749,13 @@ export function SeriesDetail() {
             </div>
           </FocusContext.Provider>
 
-          {/* Load More */}
+          {/* Load More — extracted to avoid conditional useSpatialFocusable anti-pattern */}
           {hasMore && (
-            <div className="px-6 lg:px-10 mt-4">
-              <button
-                ref={loadMoreRef}
-                {...loadMoreFocusProps}
-                onClick={handleLoadMore}
-                className={`w-full py-3 rounded-xl border text-sm font-medium transition-all ${
-                  loadMoreFocusRing
-                    ? 'bg-surface-raised ring-2 ring-teal ring-offset-2 ring-offset-obsidian text-text-primary'
-                    : 'bg-surface-raised border-border text-text-secondary hover:border-teal/20 hover:text-text-primary'
-                }`}
-              >
-                Load More ({filteredEpisodes.length - visibleCount} remaining)
-              </button>
-            </div>
+            <LoadMoreButton
+              seriesId={seriesId}
+              remaining={filteredEpisodes.length - visibleCount}
+              onLoadMore={handleLoadMore}
+            />
           )}
 
           {/* Total episodes info */}

--- a/src/features/vod/components/MovieDetail.tsx
+++ b/src/features/vod/components/MovieDetail.tsx
@@ -32,8 +32,9 @@ export function MovieDetail() {
     focusable: false,
   });
 
-  const { focusKey: actionsFocusKey } = useSpatialContainer({
+  const { ref: actionsRef, focusKey: actionsFocusKey } = useSpatialContainer({
     focusKey: `movie-actions-${vodId}`,
+    focusable: false,
   });
 
   const { ref: backRef, showFocusRing: backFocusRing, focusProps: backFocusProps } = useSpatialFocusable({
@@ -88,6 +89,7 @@ export function MovieDetail() {
     <FocusContext.Provider value={contentFocusKey}>
       <div ref={contentRef}>
         <FocusContext.Provider value={actionsFocusKey}>
+          <div ref={actionsRef}>
           {/* Back button */}
           <button
             ref={backRef}
@@ -172,6 +174,7 @@ export function MovieDetail() {
                 {savedProgress > 0 ? 'Resume' : 'Play'}
               </Button>
             </div>
+          </div>
           </div>
         </FocusContext.Provider>
 

--- a/src/shared/components/CategoryGrid.tsx
+++ b/src/shared/components/CategoryGrid.tsx
@@ -41,6 +41,7 @@ export function CategoryGrid({ categories, selectedId, onSelect, focusKey: propF
 
   const { ref: containerRef, focusKey } = useSpatialContainer({
     focusKey: parentId,
+    focusable: false,
   });
 
   return (

--- a/src/shared/components/ContentRail.tsx
+++ b/src/shared/components/ContentRail.tsx
@@ -78,6 +78,7 @@ function ContentRailInner({
 
   const { ref, focusKey } = useSpatialContainer({
     focusKey: railId,
+    focusable: false,
     saveLastFocusedChild: true,
     isFocusBoundary: true,
     focusBoundaryDirections: ['left', 'right'],

--- a/src/shared/hooks/useSpatialNav.ts
+++ b/src/shared/hooks/useSpatialNav.ts
@@ -89,14 +89,14 @@ interface UseSpatialContainerOptions {
 
 /**
  * Wrapper for container elements (rails, pages, nav groups).
- * Containers are focusable so norigin's focus tree can traverse through them
- * to reach leaf cards. Focus always delegates to children via getNextFocusKey.
+ * Containers default to focusable: false so they don't compete in smartNavigate
+ * distance calculations — only leaf elements (cards, buttons) should be focusable.
  * Must wrap children in FocusContext.Provider.
  */
 export function useSpatialContainer(options: UseSpatialContainerOptions = {}) {
   const { ref, focusSelf, focusKey, hasFocusedChild } = useFocusable({
     focusKey: options.focusKey,
-    focusable: options.focusable ?? true,
+    focusable: options.focusable ?? false,
     saveLastFocusedChild: options.saveLastFocusedChild ?? true,
     trackChildren: options.trackChildren ?? true,
     autoRestoreFocus: options.autoRestoreFocus,


### PR DESCRIPTION
## Summary
- **Root cause**: norigin's `smartNavigate` measures distance to ALL `focusable:true` elements. Container elements (rails, pages) have large bounding rects that win over small leaf elements (cards, buttons), blocking D-pad navigation across sections.
- Changed `useSpatialContainer` default from `focusable:true` to `focusable:false` — only leaf elements should participate in distance calculations
- Fixed SeriesDetail: added missing DOM refs to actions/episodes containers, extracted LoadMoreButton to avoid conditional render anti-pattern (ghost node)
- Fixed MovieDetail: added missing DOM ref to actions container
- Fixed LivePage: 5 containers now `focusable:false` with proper refs
- Applied consistently across all 11 files with `useSpatialContainer` calls

## What this fixes
1. **Can't navigate Up from Continue Watching to top nav** — ContentRail containers were winning smartNavigate over NavItems
2. **Series detail page focus broken** — containers had no DOM refs, norigin couldn't calculate child positions
3. **Prevents future bugs** — default is now `focusable:false` for all containers

## Test plan
- [ ] From Home page CW rail, press Up arrow — should reach Home/Telugu nav items
- [ ] Series detail page: episodes should be focusable, Up/Down navigation works
- [ ] Movie detail page: Play button auto-focused, Back button reachable
- [ ] Live page: sidebar categories navigable, grid channels focusable
- [ ] Search page: search input, tabs, results all navigable

Generated with [Claude Code](https://claude.com/claude-code)