### PR TITLE
fix: SeriesDetail spatial nav — add missing refs, extract LoadMoreButton

### DIFF
--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -68,6 +68,35 @@ function ResumeButton({ seriesId, episode, seriesName, onResume }: {
   );
 }
 
+/** Extracted so useSpatialFocusable only runs when the button is actually mounted */
+function LoadMoreButton({ seriesId, remaining, onLoadMore }: {
+  seriesId: string;
+  remaining: number;
+  onLoadMore: () => void;
+}) {
+  const { ref, showFocusRing, focusProps } = useSpatialFocusable({
+    focusKey: `series-load-more-${seriesId}`,
+    onEnterPress: onLoadMore,
+  });
+
+  return (
+    <div className="px-6 lg:px-10 mt-4">
+      <button
+        ref={ref}
+        {...focusProps}
+        onClick={onLoadMore}
+        className={`w-full py-3 rounded-xl border text-sm font-medium transition-all ${
+          showFocusRing
+            ? 'bg-surface-raised ring-2 ring-teal ring-offset-2 ring-offset-obsidian text-text-primary'
+            : 'bg-surface-raised border-border text-text-secondary hover:border-teal/20 hover:text-text-primary'
+        }`}
+      >
+        Load More ({remaining} remaining)
+      </button>
+    </div>
+  );
+}
+
 function formatEpisodeDate(unixTimestamp: string): string {
   const ts = parseInt(unixTimestamp, 10);
   if (!ts || isNaN(ts)) return '';
@@ -383,11 +412,11 @@ export function SeriesDetail() {
     focusable: false,
   });
 
-  const { focusKey: actionsFocusKey } = useSpatialContainer({
+  const { ref: actionsRef, focusKey: actionsFocusKey } = useSpatialContainer({
     focusKey: `series-actions-${seriesId}`,
   });
 
-  const { focusKey: episodesFocusKey } = useSpatialContainer({
+  const { ref: episodesRef, focusKey: episodesFocusKey } = useSpatialContainer({
     focusKey: `series-episodes-${seriesId}`,
   });
 
@@ -399,11 +428,6 @@ export function SeriesDetail() {
   const { ref: closeRef, showFocusRing: closeFocusRing, focusProps: closeFocusProps } = useSpatialFocusable({
     focusKey: `series-close-${seriesId}`,
     onEnterPress: () => setPlayingEpisodeId(null),
-  });
-
-  const { ref: loadMoreRef, showFocusRing: loadMoreFocusRing, focusProps: loadMoreFocusProps } = useSpatialFocusable({
-    focusKey: `series-load-more-${seriesId}`,
-    onEnterPress: handleLoadMore,
   });
 
   // Auto-focus resume button or back button when page loads
@@ -449,6 +473,7 @@ export function SeriesDetail() {
       <FocusContext.Provider value={contentFocusKey}>
         <div ref={contentRef} className="pb-12">
           <FocusContext.Provider value={actionsFocusKey}>
+            <div ref={actionsRef}>
             {/* Back button */}
             <div className="px-6 lg:px-10 pt-4 mb-4">
               <button
@@ -565,6 +590,7 @@ export function SeriesDetail() {
                 }}
               />
             )}
+            </div>
           </FocusContext.Provider>
 
           {/* Plot */}
@@ -694,7 +720,10 @@ export function SeriesDetail() {
 
           {/* Episode List */}
           <FocusContext.Provider value={episodesFocusKey}>
-            <div ref={episodeListRef} className="space-y-2 px-6 lg:px-10">
+            <div ref={(el: HTMLDivElement | null) => {
+              (episodesRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+              episodeListRef.current = el;
+            }} className="space-y-2 px-6 lg:px-10">
               {visibleEpisodes.length === 0 && episodeSearch ? (
                 <div className="py-12 text-center">
                   <p className="text-text-muted text-sm">
@@ -718,22 +747,13 @@ export function SeriesDetail() {
             </div>
           </FocusContext.Provider>
 
-          {/* Load More */}
+          {/* Load More — extracted to avoid conditional useSpatialFocusable anti-pattern */}
           {hasMore && (
-            <div className="px-6 lg:px-10 mt-4">
-              <button
-                ref={loadMoreRef}
-                {...loadMoreFocusProps}
-                onClick={handleLoadMore}
-                className={`w-full py-3 rounded-xl border text-sm font-medium transition-all ${
-                  loadMoreFocusRing
-                    ? 'bg-surface-raised ring-2 ring-teal ring-offset-2 ring-offset-obsidian text-text-primary'
-                    : 'bg-surface-raised border-border text-text-secondary hover:border-teal/20 hover:text-text-primary'
-                }`}
-              >
-                Load More ({filteredEpisodes.length - visibleCount} remaining)
-              </button>
-            </div>
+            <LoadMoreButton
+              seriesId={seriesId}
+              remaining={filteredEpisodes.length - visibleCount}
+              onLoadMore={handleLoadMore}
+            />
           )}
 
           {/* Total episodes info */}


### PR DESCRIPTION
## Summary
- Add DOM refs to `actionsFocusKey` and `episodesFocusKey` containers — norigin needs these to calculate child element positions (were missing → focus: none on series page)
- Extract `LoadMoreButton` into separate component to fix conditional render anti-pattern (hook called unconditionally but button rendered conditionally = ghost node)
- Keeps `focusable: true` on containers (no other changes)

## Test plan
- [ ] Navigate to a series detail page — episodes should be focusable with D-pad
- [ ] Back button and Resume button should receive focus on load
- [ ] Load More button (if visible) should be focusable

Generated with [Claude Code](https://claude.com/claude-code)