### PR TITLE
fix: add left/right focus boundary to series containers

### DIFF
--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -414,10 +414,14 @@ export function SeriesDetail() {
 
   const { ref: actionsRef, focusKey: actionsFocusKey } = useSpatialContainer({
     focusKey: `series-actions-${seriesId}`,
+    isFocusBoundary: true,
+    focusBoundaryDirections: ['left', 'right'],
   });
 
   const { ref: episodesRef, focusKey: episodesFocusKey } = useSpatialContainer({
     focusKey: `series-episodes-${seriesId}`,
+    isFocusBoundary: true,
+    focusBoundaryDirections: ['left', 'right'],
   });
 
   const { ref: backRef, showFocusRing: backFocusRing, focusProps: backFocusProps } = useSpatialFocusable({


### PR DESCRIPTION
## Summary
- ArrowLeft on episode items escapes the container → focus becomes undefined → stuck in bootstrap loop
- Add `isFocusBoundary` with `['left', 'right']` to both actions and episodes containers
- Left/Right now stays within the section, Up/Down still moves between sections

## Test plan
- [ ] Series detail: navigate Down through episodes, then press Left — focus should stay on current episode
- [ ] Up/Down still works between resume button and episodes

Generated with [Claude Code](https://claude.com/claude-code)