### PR TITLE
fix: scroll focused episode into view on D-pad navigation

### DIFF
--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -135,6 +135,9 @@ function FocusableEpisodeItem({
   const { ref, showFocusRing, focusProps } = useSpatialFocusable({
     focusKey: `series-ep-${ep.id}`,
     onEnterPress: () => playEpisode(ep),
+    onFocus: (layout) => {
+      layout.node?.scrollIntoView({ behavior: 'instant', block: 'nearest' });
+    },
   });
 
   const addedDate = formatEpisodeDate(ep.added);


### PR DESCRIPTION
## Summary
- Episodes weren't visually scrolling when navigating with D-pad — focus changed in norigin but the focused episode stayed off-screen
- Add `onFocus: scrollIntoView` to `FocusableEpisodeItem` (same pattern as ContentCard)

## Test plan
- [ ] Series detail: press Down through episodes — page should scroll to keep focused episode visible

Generated with [Claude Code](https://claude.com/claude-code)