### PR TITLE
fix: add SSH retry logic to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,14 +13,18 @@ jobs:
     environment: production
     steps:
       - name: Deploy to VPS
-        uses: appleboy/ssh-action@v1
+        uses: nick-fields/retry@v3
         with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          timeout: 60s
-          command_timeout: 8m
-          script: |
+          max_attempts: 3
+          timeout_minutes: 10
+          retry_wait_seconds: 30
+          command: |
+            which ssh-agent || sudo apt-get install -y openssh-client
+            eval $(ssh-agent -s)
+            echo "${{ secrets.SSH_KEY }}" | tr -d '\r' | ssh-add -
+            mkdir -p ~/.ssh
+            ssh-keyscan -t rsa ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
+            ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << 'DEPLOY_SCRIPT'
             set -e
             echo "Pulling latest code..."
             cd ~/streamvault-frontend
@@ -45,13 +49,18 @@ jobs:
             docker logs streamvault_frontend --tail 50
             docker restart streamvault_frontend
             exit 1
+            DEPLOY_SCRIPT
 
       - name: Cleanup
         if: success()
-        uses: appleboy/ssh-action@v1
+        uses: nick-fields/retry@v3
         with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          key: ${{ secrets.SSH_KEY }}
-          timeout: 60s
-          script: docker image prune -f
+          max_attempts: 2
+          timeout_minutes: 3
+          retry_wait_seconds: 15
+          command: |
+            eval $(ssh-agent -s)
+            echo "${{ secrets.SSH_KEY }}" | tr -d '\r' | ssh-add -
+            mkdir -p ~/.ssh
+            ssh-keyscan -t rsa ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
+            ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} 'docker image prune -f'


### PR DESCRIPTION
## Summary
- Replace `appleboy/ssh-action` with `nick-fields/retry@v3` wrapping raw SSH commands
- 3 attempts with 30s wait between retries for deploy step
- 2 attempts with 15s wait for cleanup step
- Fixes transient SSH timeouts caused by Hostinger UFW blocking dynamic GitHub Actions runner IPs

## Test plan
- [ ] Merge and verify next deploy succeeds (or retries and succeeds)
- [ ] Check workflow logs show retry attempts if first SSH fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)