### PR TITLE
fix: complete sort default revert to name_asc

### DIFF
--- a/src/features/language/components/MoviesTabContent.tsx
+++ b/src/features/language/components/MoviesTabContent.tsx
@@ -167,7 +167,7 @@ export function MoviesTabContent({ language, lang }: MoviesTabContentProps) {
 
   const [searchQuery, setSearchQuery] = useState('');
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
-  const [sortKey, setSortKey] = useState<SortKey>('recent');
+  const [sortKey, setSortKey] = useState<SortKey>('name_asc');
   const debouncedSearch = useDebounce(searchQuery, 300);
 
   const hasActiveFilters = !!debouncedSearch || activeCategory !== null || sortKey !== 'name_asc';

--- a/src/features/language/components/SeriesTabContent.tsx
+++ b/src/features/language/components/SeriesTabContent.tsx
@@ -159,7 +159,7 @@ export function SeriesTabContent({ language }: SeriesTabContentProps) {
 
   const [searchQuery, setSearchQuery] = useState('');
   const [activeChannel, setActiveChannel] = useState<string | null>(null);
-  const [sortKey, setSortKey] = useState<SortKey>('recent');
+  const [sortKey, setSortKey] = useState<SortKey>('name_asc');
   const debouncedSearch = useDebounce(searchQuery, 300);
   const hasActiveFilters = !!debouncedSearch || activeChannel !== null || sortKey !== 'name_asc';
 


### PR DESCRIPTION
## Summary
- Fix useState initializer from `'recent'` to `'name_asc'` in both MoviesTabContent and SeriesTabContent
- PR #59 missed this line, causing hasActiveFilters to be true on load (grid mode instead of rails)

## Test plan
- [ ] Movies tab shows rails (horizontal scroll) on load, not grid
- [ ] Series tab shows rails on load, not grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)