### PR TITLE
fix: restore deploy.yml, fix Enter key on cards

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,18 +13,14 @@ jobs:
     environment: production
     steps:
       - name: Deploy to VPS
-        uses: nick-fields/retry@v3
+        uses: appleboy/ssh-action@v1
         with:
-          max_attempts: 3
-          timeout_minutes: 10
-          retry_wait_seconds: 30
-          command: |
-            which ssh-agent || sudo apt-get install -y openssh-client
-            eval $(ssh-agent -s)
-            echo "${{ secrets.SSH_KEY }}" | tr -d '\r' | ssh-add -
-            mkdir -p ~/.ssh
-            ssh-keyscan -t rsa ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-            ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << 'DEPLOY_SCRIPT'
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          timeout: 60s
+          command_timeout: 8m
+          script: |
             set -e
             echo "Pulling latest code..."
             cd ~/streamvault-frontend
@@ -49,18 +45,13 @@ jobs:
             docker logs streamvault_frontend --tail 50
             docker restart streamvault_frontend
             exit 1
-            DEPLOY_SCRIPT
 
       - name: Cleanup
         if: success()
-        uses: nick-fields/retry@v3
+        uses: appleboy/ssh-action@v1
         with:
-          max_attempts: 2
-          timeout_minutes: 3
-          retry_wait_seconds: 15
-          command: |
-            eval $(ssh-agent -s)
-            echo "${{ secrets.SSH_KEY }}" | tr -d '\r' | ssh-add -
-            mkdir -p ~/.ssh
-            ssh-keyscan -t rsa ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-            ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} 'docker image prune -f'
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          timeout: 60s
+          script: docker image prune -f

--- a/src/shared/providers/SpatialNavProvider.tsx
+++ b/src/shared/providers/SpatialNavProvider.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import { init, setFocus, getCurrentFocusKey } from '@noriginmedia/norigin-spatial-navigation';
+import { init, setFocus, getCurrentFocusKey, setKeyMap } from '@noriginmedia/norigin-spatial-navigation';
 import { useUIStore } from '@lib/store';
 
 // Check URL param for debug mode (e.g. ?debug=spatial)
@@ -17,6 +17,9 @@ init({
   throttle: 100,
   throttleKeypresses: true,
 });
+
+// Extend Enter key mapping to include Fire TV DPAD_CENTER (keyCode 23)
+setKeyMap({ enter: [13, 23, 'Enter'] });
 
 interface SpatialNavProviderProps {
   children: ReactNode;
@@ -52,10 +55,25 @@ export function SpatialNavProvider({ children }: SpatialNavProviderProps) {
         e.preventDefault();  // Prevent native scroll — norigin handles focus movement, card onFocus scrolls into view
       }
 
-      const isNavKey = isArrow || ['Enter', 'Escape', 'Backspace'].includes(e.key);
+      const isEnter = e.key === 'Enter' || e.keyCode === 13 || e.keyCode === 23;
+      const isNavKey = isArrow || isEnter || ['Escape', 'Backspace'].includes(e.key);
 
       if (isNavKey) {
         setInputMode('keyboard');
+      }
+
+      // Enter/Select: click the focused card directly.
+      // norigin's onEnterPress relies on native events with shouldUseNativeEvents:true,
+      // but cards are <div> elements (not <button>), so native Enter doesn't trigger click.
+      // Also handles Fire TV DPAD_CENTER (keyCode 23) which norigin may not map.
+      if (isEnter && !isInInput) {
+        const focusedEl = document.querySelector('[data-focused="true"]') as HTMLElement;
+        if (focusedEl) {
+          focusedEl.click();
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
       }
 
       // If in an input and arrow pressed, blur so spatial nav takes over


### PR DESCRIPTION
## Summary
- Reverts deploy.yml from `nick-fields/retry@v3` back to `appleboy/ssh-action@v1` — retry wrapper was causing more failures than the original
- Fixes Enter/Select key not working on movie/series cards:
  - Cards are `<div>` elements, so native Enter doesn't trigger click with `shouldUseNativeEvents: true`
  - Added direct click dispatch on `[data-focused="true"]` element in capture-phase handler
  - Extended norigin keyMap to include Fire TV DPAD_CENTER (keyCode 23)
  - `stopPropagation` prevents double-fire from norigin's own handler

## Test plan
- [ ] Navigate movies/series with D-pad, press Enter — should open detail page
- [ ] Test on Fire Stick — center button should select cards
- [ ] Verify deploy workflow succeeds on next merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)