### PR TITLE
fix: Enter key selection + series focus for non-resume series

### DIFF
--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -9,7 +9,7 @@ import { formatDuration } from '@shared/utils/formatDuration';
 import { parseGenres } from '@shared/utils/parseGenres';
 import { PageTransition } from '@shared/components/PageTransition';
 import { usePlayerStore } from '@lib/store';
-import { useSpatialFocusable, useSpatialContainer, FocusContext, setFocus } from '@shared/hooks/useSpatialNav';
+import { useSpatialFocusable, useSpatialContainer, FocusContext, setFocus, doesFocusableExist } from '@shared/hooks/useSpatialNav';
 
 type EpisodeSortKey = 'latest' | 'oldest' | 'episode';
 const EPISODES_PER_PAGE = 50;
@@ -518,19 +518,31 @@ export function SeriesDetail() {
     onEnterPress: () => navigate({ to: '/series' }),
   });
 
-  // Auto-focus: try specific targets, then fall back to SN:ROOT which finds any focusable
+  // Auto-focus: try specific targets using doesFocusableExist to avoid silently setting
+  // focus on non-existent keys. Without this check, setFocus('series-resume-X') sets the
+  // internal focus key even when no resume button is mounted, breaking all subsequent focus.
   useEffect(() => {
     if (!isLoading && data) {
       const tryFocus = () => {
-        try { setFocus(`series-resume-${seriesId}`); return; } catch { /* not mounted */ }
-        if (computedSeasons.length > 0 && computedSeasons[0]) {
-          try { setFocus(`series-season-${computedSeasons[0].season_number}`); return; } catch { /* noop */ }
+        const resumeKey = `series-resume-${seriesId}`;
+        if (doesFocusableExist(resumeKey)) {
+          setFocus(resumeKey);
+          return;
         }
-        try { setFocus(`series-back-${seriesId}`); return; } catch { /* noop */ }
-        // Final fallback: let norigin find any registered focusable
+        if (computedSeasons.length > 0 && computedSeasons[0]) {
+          const seasonKey = `series-season-${computedSeasons[0].season_number}`;
+          if (doesFocusableExist(seasonKey)) {
+            setFocus(seasonKey);
+            return;
+          }
+        }
+        const backKey = `series-back-${seriesId}`;
+        if (doesFocusableExist(backKey)) {
+          setFocus(backKey);
+          return;
+        }
         try { setFocus('SN:ROOT'); } catch { /* noop */ }
       };
-      // Try at 200ms, retry at 500ms if focus is still none
       const t1 = setTimeout(tryFocus, 200);
       const t2 = setTimeout(tryFocus, 500);
       return () => { clearTimeout(t1); clearTimeout(t2); };

--- a/src/shared/hooks/useSpatialNav.ts
+++ b/src/shared/hooks/useSpatialNav.ts
@@ -3,12 +3,13 @@ import {
   useFocusable,
   FocusContext,
   setFocus,
+  doesFocusableExist,
   type FocusableComponentLayout,
   type FocusDetails,
 } from '@noriginmedia/norigin-spatial-navigation';
 import { useUIStore } from '@lib/store';
 
-export { FocusContext, setFocus };
+export { FocusContext, setFocus, doesFocusableExist };
 
 // Re-export pause/resume for player TV mode
 export { pause as pauseSpatialNav, resume as resumeSpatialNav } from '@noriginmedia/norigin-spatial-navigation';
@@ -69,6 +70,7 @@ export function useSpatialFocusable(options: UseSpatialFocusableOptions = {}) {
     showFocusRing,
     focusProps: {
       onMouseEnter,
+      'data-focus-key': focusKey,
     },
   };
 }

--- a/src/shared/providers/SpatialNavProvider.tsx
+++ b/src/shared/providers/SpatialNavProvider.tsx
@@ -62,17 +62,20 @@ export function SpatialNavProvider({ children }: SpatialNavProviderProps) {
         setInputMode('keyboard');
       }
 
-      // Enter/Select: click the focused card directly.
-      // norigin's onEnterPress relies on native events with shouldUseNativeEvents:true,
-      // but cards are <div> elements (not <button>), so native Enter doesn't trigger click.
-      // Also handles Fire TV DPAD_CENTER (keyCode 23) which norigin may not map.
+      // Enter/Select: click the focused element directly.
+      // norigin's onEnterPress can be unreliable with shouldUseNativeEvents:true on <div> cards.
+      // Also handles Fire TV DPAD_CENTER (keyCode 23).
+      // Uses data-focus-key attribute set by useSpatialFocusable to find the focused DOM element.
       if (isEnter && !isInInput) {
-        const focusedEl = document.querySelector('[data-focused="true"]') as HTMLElement;
-        if (focusedEl) {
-          focusedEl.click();
-          e.preventDefault();
-          e.stopPropagation();
-          return;
+        const currentKey = getCurrentFocusKey();
+        if (currentKey) {
+          const focusedEl = document.querySelector(`[data-focus-key="${CSS.escape(currentKey)}"]`) as HTMLElement;
+          if (focusedEl) {
+            focusedEl.click();
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+          }
         }
       }
 
@@ -136,7 +139,7 @@ function SpatialDebugOverlay() {
   useEffect(() => {
     function update() {
       const focusKey = getCurrentFocusKey() || 'none';
-      const focusedEls = document.querySelectorAll('[data-focused="true"]');
+      const focusedEls = focusKey !== 'none' ? document.querySelectorAll(`[data-focus-key="${CSS.escape(focusKey)}"]`) : [];
       setInfo((prev) => ({
         ...prev,
         focusKey,


### PR DESCRIPTION
## Summary
- **Enter key**: Previous fix queried `[data-focused="true"]` but norigin doesn't set that DOM attribute. Now adds `data-focus-key` to all focusable elements and queries by `getCurrentFocusKey()`.
- **Series without resume**: `setFocus('series-resume-X')` silently sets norigin's internal focus key even when no resume button exists, breaking all subsequent navigation. Now uses `doesFocusableExist()` pre-check before calling `setFocus()`.

## Test plan
- [ ] Open a series you've never watched (no resume) — should auto-focus on Season tab
- [ ] Open a series with resume — should auto-focus on Resume button
- [ ] Navigate to any card with D-pad, press Enter — should open detail page
- [ ] Spatial debug overlay should show `data-focused els: 1` when focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)