### PR TITLE
feat: global layout padding + Start Over button

### DIFF
--- a/src/features/language/CategoryGridPage.tsx
+++ b/src/features/language/CategoryGridPage.tsx
@@ -129,7 +129,7 @@ export function CategoryGridPage() {
   if (!lang || !categoryId) {
     return (
       <PageTransition>
-        <div className="px-6 lg:px-10 py-20 text-center">
+        <div className="py-20 text-center">
           <p className="text-text-muted text-lg">Category not found</p>
         </div>
       </PageTransition>
@@ -138,7 +138,7 @@ export function CategoryGridPage() {
 
   return (
     <PageTransition>
-      <div className="px-6 lg:px-10 py-6">
+      <div className="py-6">
         {/* Breadcrumb */}
         <nav className="flex items-center gap-2 text-sm text-text-muted mb-4">
           <Link

--- a/src/features/language/LanguageHubPage.tsx
+++ b/src/features/language/LanguageHubPage.tsx
@@ -96,7 +96,7 @@ export function LanguageHubPage() {
   if (!lang) {
     return (
       <PageTransition>
-        <div className="px-6 lg:px-10 py-20 text-center">
+        <div className="py-20 text-center">
           <p className="text-text-muted text-lg">Language not found</p>
         </div>
       </PageTransition>
@@ -109,7 +109,7 @@ export function LanguageHubPage() {
       <FocusContext.Provider value={focusKey}>
       <div ref={containerRef} className="space-y-4 pb-12">
         {/* Language Tabs */}
-        <div className="px-6 lg:px-10 pt-2">
+        <div className="pt-2">
           <div className="flex items-center gap-2">
             {LANGUAGE_TABS.map((lt) => (
               <FocusableLanguageTab
@@ -131,7 +131,7 @@ export function LanguageHubPage() {
         </div>
 
         {/* Content Tabs */}
-        <div className="px-6 lg:px-10 relative z-10">
+        <div className="relative z-10">
           <div
             className="flex items-center gap-1 border-b border-border-subtle"
             role="tablist"

--- a/src/features/language/components/LiveTabContent.tsx
+++ b/src/features/language/components/LiveTabContent.tsx
@@ -150,7 +150,7 @@ export function LiveTabContent({ language, lang }: LiveTabContentProps) {
     <div className="space-y-6">
       {/* Category Filter Chips */}
       {categoryChips.length > 1 && (
-        <div className="flex gap-2 px-6 lg:px-10 overflow-x-auto scrollbar-hide pb-1">
+        <div className="flex gap-2 overflow-x-auto scrollbar-hide pb-1">
           <FocusableChip
             id="live-chip-all"
             label={`All (${totalCount})`}
@@ -172,7 +172,7 @@ export function LiveTabContent({ language, lang }: LiveTabContentProps) {
       )}
 
       {/* Search Bar */}
-      <div className="flex items-center gap-3 px-6 lg:px-10 flex-wrap">
+      <div className="flex items-center gap-3 flex-wrap">
         <FocusableSearchInput
           value={searchQuery}
           onChange={setSearchQuery}
@@ -214,7 +214,7 @@ export function LiveTabContent({ language, lang }: LiveTabContentProps) {
             icon="content"
           />
         ) : (
-          <div className="px-6 lg:px-10">
+          <div>
             <p className="text-text-muted text-xs mb-3">
               {processedChannels.length} channel
               {processedChannels.length !== 1 ? 's' : ''}

--- a/src/features/language/components/MoviesTabContent.tsx
+++ b/src/features/language/components/MoviesTabContent.tsx
@@ -215,7 +215,7 @@ export function MoviesTabContent({ language, lang }: MoviesTabContentProps) {
   return (
     <div className="space-y-6">
       {/* Filter Bar */}
-      <div className="px-6 lg:px-10 space-y-4">
+      <div className="space-y-4">
         {/* Category Chips */}
         {categoryChips.length > 1 && (
           <div className="flex gap-2 overflow-x-auto scrollbar-hide pb-1">
@@ -304,14 +304,14 @@ export function MoviesTabContent({ language, lang }: MoviesTabContentProps) {
             </ContentRail>
           ))}
           {!railsLoading && movieRails.length === 0 && (
-            <div className="px-6 lg:px-10 py-12 text-center">
+            <div className="py-12 text-center">
               <p className="text-text-muted text-lg">No {language} movies found</p>
             </div>
           )}
         </div>
       ) : (
         /* Grid mode (filters active) */
-        <div className="px-6 lg:px-10">
+        <div>
           {allLoading ? (
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
               <SkeletonGrid count={18} aspectRatio="poster" />

--- a/src/features/language/components/SeriesTabContent.tsx
+++ b/src/features/language/components/SeriesTabContent.tsx
@@ -207,7 +207,7 @@ export function SeriesTabContent({ language }: SeriesTabContentProps) {
     <div className="space-y-5">
       {/* Channel Filter Pills */}
       {channels.length > 1 && (
-        <div className="flex gap-2 px-6 lg:px-10 overflow-x-auto scrollbar-hide pb-1">
+        <div className="flex gap-2 overflow-x-auto scrollbar-hide pb-1">
           <FocusableChip
             id="series-chip-all"
             label={`All (${totalCount})`}
@@ -227,7 +227,7 @@ export function SeriesTabContent({ language }: SeriesTabContentProps) {
       )}
 
       {/* Search + Sort Row */}
-      <div className="flex items-center gap-3 px-6 lg:px-10 flex-wrap">
+      <div className="flex items-center gap-3 flex-wrap">
         <FocusableSearchInput
           value={searchQuery}
           onChange={setSearchQuery}
@@ -258,7 +258,7 @@ export function SeriesTabContent({ language }: SeriesTabContentProps) {
       {/* Content: Rails mode vs Grid mode */}
       {isLoading ? (
         hasActiveFilters ? (
-          <div className="px-6 lg:px-10">
+          <div>
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
               <SkeletonGrid count={18} aspectRatio="poster" />
             </div>
@@ -303,7 +303,7 @@ export function SeriesTabContent({ language }: SeriesTabContentProps) {
         </div>
       ) : processedSeries.length === 0 ? (
         /* Grid mode: empty */
-        <div className="px-6 lg:px-10">
+        <div>
           <EmptyState
             title="No matching series"
             message={
@@ -316,7 +316,7 @@ export function SeriesTabContent({ language }: SeriesTabContentProps) {
         </div>
       ) : (
         /* Grid mode: results */
-        <div className="px-6 lg:px-10">
+        <div>
           {debouncedSearch && (
             <p className="text-text-muted text-xs mb-3">
               {processedSeries.length} result{processedSeries.length !== 1 ? 's' : ''}

--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -136,7 +136,7 @@ function ResumeButton({ seriesId, episode, seriesName, onResume }: {
   });
 
   return (
-    <div className="mx-6 lg:mx-10 mb-6">
+    <div className="mb-6">
       <button
         ref={ref}
         {...focusProps}
@@ -189,7 +189,7 @@ function LoadMoreButton({ seriesId, remaining, onLoadMore }: {
   });
 
   return (
-    <div className="px-6 lg:px-10 mt-4">
+    <div className="mt-4">
       <button
         ref={ref}
         {...focusProps}
@@ -552,7 +552,7 @@ export function SeriesDetail() {
   if (isLoading) {
     return (
       <PageTransition>
-        <div className="space-y-4 px-6 lg:px-10 pt-4">
+        <div className="space-y-4 pt-4">
           <Skeleton className="h-64 w-full rounded-xl" />
           <Skeleton className="h-8 w-1/2" />
           <Skeleton className="h-4 w-full" />
@@ -581,7 +581,7 @@ export function SeriesDetail() {
           <FocusContext.Provider value={actionsFocusKey}>
             <div ref={actionsRef}>
             {/* Back button */}
-            <div className="px-6 lg:px-10 pt-4 mb-4">
+            <div className="pt-4 mb-4">
               <button
                 ref={backRef}
                 {...backFocusProps}
@@ -669,13 +669,13 @@ export function SeriesDetail() {
 
           {/* Plot */}
           {info.plot && (
-            <p className="text-text-secondary text-sm lg:text-base leading-relaxed mb-6 px-6 lg:px-10 max-w-3xl">
+            <p className="text-text-secondary text-sm lg:text-base leading-relaxed mb-6 max-w-3xl">
               {info.plot}
             </p>
           )}
 
           {/* Cast/Director */}
-          <div className="flex gap-6 mb-6 text-sm px-6 lg:px-10">
+          <div className="flex gap-6 mb-6 text-sm">
             {info.director && (
               <div>
                 <span className="text-text-muted">Director: </span>
@@ -694,7 +694,7 @@ export function SeriesDetail() {
           <FocusContext.Provider value={controlsFocusKey}>
             <div ref={controlsRef}>
               {/* Season Tabs */}
-              <div className="px-6 lg:px-10 mb-4">
+              <div className="mb-4">
                 <div className="flex gap-2 overflow-x-auto scrollbar-hide pb-2" role="tablist">
                   {computedSeasons.map((season) => (
                     <FocusableSeasonTab
@@ -713,7 +713,7 @@ export function SeriesDetail() {
               </div>
 
               {/* Episode Controls: Search + Sort + Count */}
-              <div className="px-6 lg:px-10 mb-4">
+              <div className="mb-4">
                 <div className="flex items-center gap-3 flex-wrap">
                   <FocusableSearchInput
                     value={episodeSearch}
@@ -756,7 +756,7 @@ export function SeriesDetail() {
             <div ref={(el: HTMLDivElement | null) => {
               (episodesRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
               episodeListRef.current = el;
-            }} className="space-y-2 px-6 lg:px-10">
+            }} className="space-y-2">
               {visibleEpisodes.length === 0 && episodeSearch ? (
                 <div className="py-12 text-center">
                   <p className="text-text-muted text-sm">
@@ -787,7 +787,7 @@ export function SeriesDetail() {
 
           {/* Total episodes info */}
           {filteredEpisodes.length > EPISODES_PER_PAGE && (
-            <div className="px-6 lg:px-10 mt-3">
+            <div className="mt-3">
               <p className="text-text-muted text-xs text-center">
                 Showing {Math.min(visibleCount, filteredEpisodes.length)} of{' '}
                 {filteredEpisodes.length} episodes

--- a/src/features/series/components/SeriesPage.tsx
+++ b/src/features/series/components/SeriesPage.tsx
@@ -49,7 +49,7 @@ export function SeriesPage() {
     <PageTransition>
       <FocusContext.Provider value={focusKey}>
         <div ref={containerRef} className="pt-4 pb-12 space-y-4">
-          <h1 className="font-display text-2xl font-bold text-text-primary px-6 lg:px-10">
+          <h1 className="font-display text-2xl font-bold text-text-primary">
             Series
           </h1>
 

--- a/src/features/vod/components/MovieDetail.tsx
+++ b/src/features/vod/components/MovieDetail.tsx
@@ -11,12 +11,37 @@ import { parseGenres } from '@shared/utils/parseGenres';
 import { PlayerPage } from '@features/player/components/PlayerPage';
 import { useSpatialFocusable, useSpatialContainer, FocusContext, setFocus } from '@shared/hooks/useSpatialNav';
 
+function StartOverButton({ vodId, onStartOver }: { vodId: string; onStartOver: () => void }) {
+  const { ref, showFocusRing, focusProps } = useSpatialFocusable({
+    focusKey: `vod-restart-${vodId}`,
+    onEnterPress: onStartOver,
+  });
+
+  return (
+    <Button
+      ref={ref}
+      {...focusProps}
+      variant="secondary"
+      size="lg"
+      onClick={onStartOver}
+      className={showFocusRing ? 'ring-2 ring-offset-2 ring-offset-obsidian ring-teal' : ''}
+      data-focus-key={`vod-restart-${vodId}`}
+    >
+      <svg className="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h5M20 20v-5h-5M4 9a8 8 0 0113.09-3.09L20 9M20 15a8 8 0 01-13.09 3.09L4 15" />
+      </svg>
+      Start Over
+    </Button>
+  );
+}
+
 export function MovieDetail() {
   const { vodId } = useParams({ from: '/_authenticated/vod/$vodId' });
   const navigate = useNavigate();
   const { data, isLoading } = useVODInfo(vodId);
   const { data: watchHistory } = useWatchHistory();
   const [isPlayerOpen, setIsPlayerOpen] = useState(false);
+  const [playerStartTime, setPlayerStartTime] = useState(0);
 
   // Find saved progress for this movie
   const savedProgress = useMemo(() => {
@@ -48,7 +73,7 @@ export function MovieDetail() {
 
   const { ref: playRef, showFocusRing: playFocusRing, focusProps: playFocusProps } = useSpatialFocusable({
     focusKey: `vod-play-${vodId}`,
-    onEnterPress: () => setIsPlayerOpen(true),
+    onEnterPress: () => { setPlayerStartTime(savedProgress); setIsPlayerOpen(true); },
   });
 
   // Auto-focus Play button when page loads
@@ -123,7 +148,7 @@ export function MovieDetail() {
                 streamType="vod"
                 streamId={vodId}
                 streamName={info.name}
-                startTime={savedProgress}
+                startTime={playerStartTime}
                 onClose={() => setIsPlayerOpen(false)}
               />
             </div>
@@ -159,18 +184,24 @@ export function MovieDetail() {
                   <Badge key={g} variant="teal">{g}</Badge>
                 ))}
               </div>
-              <Button
-                ref={playRef}
-                {...playFocusProps}
-                size="lg"
-                onClick={() => setIsPlayerOpen(true)}
-                className={playFocusRing ? 'ring-2 ring-offset-2 ring-offset-obsidian ring-teal' : ''}
-              >
-                <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M8 5v14l11-7z" />
-                </svg>
-                {savedProgress > 0 ? 'Resume' : 'Play'}
-              </Button>
+              <div className="flex gap-3">
+                <Button
+                  ref={playRef}
+                  {...playFocusProps}
+                  size="lg"
+                  onClick={() => { setPlayerStartTime(savedProgress); setIsPlayerOpen(true); }}
+                  className={playFocusRing ? 'ring-2 ring-offset-2 ring-offset-obsidian ring-teal' : ''}
+                  data-focus-key={`vod-play-${vodId}`}
+                >
+                  <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M8 5v14l11-7z" />
+                  </svg>
+                  {savedProgress > 0 ? 'Resume' : 'Play'}
+                </Button>
+                {savedProgress > 0 && (
+                  <StartOverButton vodId={vodId} onStartOver={() => { setPlayerStartTime(0); setIsPlayerOpen(true); }} />
+                )}
+              </div>
             </div>
           </div>
         </FocusContext.Provider>

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -35,7 +35,7 @@ function AuthenticatedLayout() {
   return (
     <div className="min-h-screen bg-obsidian">
       <TopNav />
-      <main className="min-h-screen pt-14 overflow-y-auto scrollbar-hide">
+      <main className="min-h-screen pt-14 px-6 lg:px-10 overflow-y-auto scrollbar-hide">
         <Outlet />
       </main>
     </div>

--- a/src/shared/components/ContentRail.tsx
+++ b/src/shared/components/ContentRail.tsx
@@ -86,13 +86,13 @@ function ContentRailInner({
   return (
     <FocusContext.Provider value={focusKey}>
       <section ref={ref} className={`${className}`}>
-        <div className="flex items-center justify-between mb-1.5 px-6 lg:px-10">
+        <div className="flex items-center justify-between mb-1.5">
           <h2 className="font-display text-lg lg:text-xl font-semibold text-text-primary">
             {title}
           </h2>
         </div>
 
-        <div className="px-6 lg:px-10">
+        <div>
           {isLoading ? (
             <div className="flex gap-4">
               {Array.from({ length: 7 }).map((_, i) => (


### PR DESCRIPTION
## Summary
- Move horizontal padding (`px-6 lg:px-10`) from 9 child components to the layout `<main>` wrapper in `_authenticated.tsx` — single source of truth for page padding
- Add "Start Over" button next to "Resume" on MovieDetail page (only shows when there's saved progress)
- StartOverButton extracted as separate component to avoid norigin conditional render anti-pattern

## Files changed (10)
- `_authenticated.tsx` — added `px-6 lg:px-10` to main wrapper
- `MovieDetail.tsx` — Start Over button + playerStartTime state
- `SeriesDetail.tsx` — removed 10 instances of duplicate padding
- `ContentRail.tsx` — removed padding from title and content wrapper
- `LanguageHubPage.tsx`, `CategoryGridPage.tsx`, `SeriesPage.tsx` — removed duplicate padding
- `SeriesTabContent.tsx`, `LiveTabContent.tsx`, `MoviesTabContent.tsx` — removed duplicate padding

## Test plan
- [ ] Verify all pages have consistent padding from screen edges
- [ ] MovieDetail: "Play" shows when no history, "Resume" + "Start Over" when history exists
- [ ] Start Over plays from beginning (startTime=0), Resume plays from saved position
- [ ] SeriesDetail hero overlay text still aligns properly (kept absolute-positioned padding)
- [ ] ContentRail horizontal scroll works correctly with layout-level padding
- [ ] D-pad navigation works on Start Over button (TV remote)

🤖 Generated with [Claude Code](https://claude.com/claude-code)