### PR TITLE
feat: denser card grids + search input keyboard forwarding

### DIFF
--- a/src/features/favorites/components/FavoritesPage.tsx
+++ b/src/features/favorites/components/FavoritesPage.tsx
@@ -121,7 +121,7 @@ export function FavoritesPage() {
 
       {/* Content */}
       {isLoading ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+        <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
           <SkeletonGrid count={12} aspectRatio="poster" />
         </div>
       ) : filtered.length === 0 ? (
@@ -131,7 +131,7 @@ export function FavoritesPage() {
           icon="favorites"
         />
       ) : (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+        <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
           {filtered.map((fav) => (
             <ContentCard
               key={`${fav.content_type}-${fav.content_id}`}

--- a/src/features/home/components/FavoritesPreview.tsx
+++ b/src/features/home/components/FavoritesPreview.tsx
@@ -36,7 +36,7 @@ export function FavoritesPreview() {
           View All
         </button>
       </div>
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+      <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
         {preview.map((item) => (
           <ContentCard
             key={`${item.content_type}-${item.content_id}`}

--- a/src/features/language/CategoryGridPage.tsx
+++ b/src/features/language/CategoryGridPage.tsx
@@ -191,7 +191,7 @@ export function CategoryGridPage() {
 
         {/* Grid */}
         {isLoading ? (
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+          <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
             <SkeletonGrid count={18} aspectRatio="poster" />
           </div>
         ) : totalItems === 0 ? (
@@ -201,7 +201,7 @@ export function CategoryGridPage() {
             icon="content"
           />
         ) : (
-          <div className="isolate grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+          <div className="isolate grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
             {/* VOD items */}
             {processedVod.map((movie) => (
               <ContentCard

--- a/src/features/language/components/LiveTabContent.tsx
+++ b/src/features/language/components/LiveTabContent.tsx
@@ -44,8 +44,23 @@ function FocusableSearchInput({ value, onChange, placeholder, focusKey }: { valu
     },
   });
 
+  // When the wrapper div has DOM focus (via shouldFocusDOMNode) and user types,
+  // forward keystrokes to the actual input element
+  const handleWrapperKeyDown = (e: React.KeyboardEvent) => {
+    if (document.activeElement === inputRef.current) return;
+    if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      inputRef.current?.focus();
+      onChange(value + e.key);
+      e.preventDefault();
+    } else if (e.key === 'Backspace' && value) {
+      inputRef.current?.focus();
+      onChange(value.slice(0, -1));
+      e.preventDefault();
+    }
+  };
+
   return (
-    <div ref={ref} {...focusProps} className={`relative flex-1 min-w-[200px] max-w-sm ${showFocusRing ? 'ring-2 ring-teal/50 rounded-lg' : ''}`}>
+    <div ref={ref} {...focusProps} onKeyDown={handleWrapperKeyDown} className={`relative flex-1 min-w-[200px] max-w-sm ${showFocusRing ? 'ring-2 ring-teal/50 rounded-lg' : ''}`}>
       <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
       </svg>
@@ -219,7 +234,7 @@ export function LiveTabContent({ language, lang }: LiveTabContentProps) {
               {processedChannels.length} channel
               {processedChannels.length !== 1 ? 's' : ''}
             </p>
-            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 gap-4">
+            <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12 gap-3">
               {processedChannels.map((channel) => (
                 <ContentCard
                   key={channel.stream_id}

--- a/src/features/language/components/MoviesTabContent.tsx
+++ b/src/features/language/components/MoviesTabContent.tsx
@@ -100,8 +100,23 @@ function FocusableSearchInput({ value, onChange, placeholder, focusKey }: { valu
     },
   });
 
+  // When the wrapper div has DOM focus (via shouldFocusDOMNode) and user types,
+  // forward keystrokes to the actual input element
+  const handleWrapperKeyDown = (e: React.KeyboardEvent) => {
+    if (document.activeElement === inputRef.current) return;
+    if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      inputRef.current?.focus();
+      onChange(value + e.key);
+      e.preventDefault();
+    } else if (e.key === 'Backspace' && value) {
+      inputRef.current?.focus();
+      onChange(value.slice(0, -1));
+      e.preventDefault();
+    }
+  };
+
   return (
-    <div ref={ref} {...focusProps} className={`relative flex-1 min-w-[200px] max-w-sm ${showFocusRing ? 'ring-2 ring-teal/50 rounded-lg' : ''}`}>
+    <div ref={ref} {...focusProps} onKeyDown={handleWrapperKeyDown} className={`relative flex-1 min-w-[200px] max-w-sm ${showFocusRing ? 'ring-2 ring-teal/50 rounded-lg' : ''}`}>
       <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
       </svg>
@@ -313,7 +328,7 @@ export function MoviesTabContent({ language, lang }: MoviesTabContentProps) {
         /* Grid mode (filters active) */
         <div>
           {allLoading ? (
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+            <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
               <SkeletonGrid count={18} aspectRatio="poster" />
             </div>
           ) : processedMovies.length === 0 ? (
@@ -336,7 +351,7 @@ export function MoviesTabContent({ language, lang }: MoviesTabContentProps) {
                 </p>
               )}
 
-              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+              <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
                 {processedMovies.map((movie) => (
                   <ContentCard
                     key={movie.stream_id}

--- a/src/features/language/components/SeriesTabContent.tsx
+++ b/src/features/language/components/SeriesTabContent.tsx
@@ -97,8 +97,23 @@ function FocusableSearchInput({ value, onChange, placeholder, focusKey }: { valu
     },
   });
 
+  // When the wrapper div has DOM focus (via shouldFocusDOMNode) and user types,
+  // forward keystrokes to the actual input element
+  const handleWrapperKeyDown = (e: React.KeyboardEvent) => {
+    if (document.activeElement === inputRef.current) return;
+    if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      inputRef.current?.focus();
+      onChange(value + e.key);
+      e.preventDefault();
+    } else if (e.key === 'Backspace' && value) {
+      inputRef.current?.focus();
+      onChange(value.slice(0, -1));
+      e.preventDefault();
+    }
+  };
+
   return (
-    <div ref={ref} {...focusProps} className={`relative flex-1 min-w-[200px] max-w-sm ${showFocusRing ? 'ring-2 ring-teal/50 rounded-lg' : ''}`}>
+    <div ref={ref} {...focusProps} onKeyDown={handleWrapperKeyDown} className={`relative flex-1 min-w-[200px] max-w-sm ${showFocusRing ? 'ring-2 ring-teal/50 rounded-lg' : ''}`}>
       <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
         <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
       </svg>
@@ -259,7 +274,7 @@ export function SeriesTabContent({ language }: SeriesTabContentProps) {
       {isLoading ? (
         hasActiveFilters ? (
           <div>
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+            <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
               <SkeletonGrid count={18} aspectRatio="poster" />
             </div>
           </div>
@@ -323,7 +338,7 @@ export function SeriesTabContent({ language }: SeriesTabContentProps) {
             </p>
           )}
 
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+          <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
             {processedSeries.map((series) => (
               <div key={series.series_id} className="relative">
                 <ContentCard

--- a/src/features/live/components/ChannelGrid.tsx
+++ b/src/features/live/components/ChannelGrid.tsx
@@ -8,7 +8,7 @@ interface ChannelGridProps {
 
 export function ChannelGrid({ channels }: ChannelGridProps) {
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+    <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
       {channels.map((channel) => (
         <ChannelCard key={channel.stream_id} channel={channel} />
       ))}

--- a/src/features/live/components/LivePage.tsx
+++ b/src/features/live/components/LivePage.tsx
@@ -307,7 +307,7 @@ export function LivePage() {
 
           <FocusContext.Provider value={channelGridFocusKey}>
           {streamsLoading ? (
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+            <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
               <SkeletonGrid count={18} aspectRatio="square" />
             </div>
           ) : filteredStreams.length === 0 ? (

--- a/src/features/search/components/SearchPage.tsx
+++ b/src/features/search/components/SearchPage.tsx
@@ -68,8 +68,23 @@ function FocusableSearchInput({ inputRef, query, setQuery }: {
     onEnterPress: () => inputRef.current?.focus(),
   });
 
+  // When the wrapper div has DOM focus (via shouldFocusDOMNode) and user types,
+  // forward keystrokes to the actual input element
+  const handleWrapperKeyDown = (e: React.KeyboardEvent) => {
+    if (document.activeElement === inputRef.current) return;
+    if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      inputRef.current?.focus();
+      setQuery(query + e.key);
+      e.preventDefault();
+    } else if (e.key === 'Backspace' && query) {
+      inputRef.current?.focus();
+      setQuery(query.slice(0, -1));
+      e.preventDefault();
+    }
+  };
+
   return (
-    <div ref={focusRef} {...focusProps} className="relative">
+    <div ref={focusRef} {...focusProps} onKeyDown={handleWrapperKeyDown} className="relative">
       <svg
         className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-text-muted"
         fill="none"
@@ -302,7 +317,7 @@ export function SearchPage() {
 
       {/* Loading */}
       {showLoading && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+        <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
           <SkeletonGrid count={12} />
         </div>
       )}
@@ -338,7 +353,7 @@ export function SearchPage() {
                     <span className="ml-2 text-sm font-normal text-text-secondary">({filteredData.live.length})</span>
                   </h2>
                 )}
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+                <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
                   {filteredData.live.map((stream) => (
                     <ContentCard
                       key={`live-${stream.stream_id}`}
@@ -366,7 +381,7 @@ export function SearchPage() {
                     <span className="ml-2 text-sm font-normal text-text-secondary">({filteredData.vod.length})</span>
                   </h2>
                 )}
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+                <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
                   {filteredData.vod.map((movie) => (
                     <ContentCard
                       key={`vod-${movie.stream_id}`}
@@ -390,7 +405,7 @@ export function SearchPage() {
                     <span className="ml-2 text-sm font-normal text-text-secondary">({filteredData.series.length})</span>
                   </h2>
                 )}
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+                <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
                   {filteredData.series.map((show) => (
                     <ContentCard
                       key={`series-${show.series_id}`}

--- a/src/features/vod/components/VODPage.tsx
+++ b/src/features/vod/components/VODPage.tsx
@@ -24,8 +24,23 @@ function FocusableSearchInput({ searchQuery, setSearchQuery }: {
     onEnterPress: () => inputRef.current?.focus(),
   });
 
+  // When the wrapper div has DOM focus (via shouldFocusDOMNode) and user types,
+  // forward keystrokes to the actual input element
+  const handleWrapperKeyDown = (e: React.KeyboardEvent) => {
+    if (document.activeElement === inputRef.current) return;
+    if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      inputRef.current?.focus();
+      setSearchQuery(searchQuery + e.key);
+      e.preventDefault();
+    } else if (e.key === 'Backspace' && searchQuery) {
+      inputRef.current?.focus();
+      setSearchQuery(searchQuery.slice(0, -1));
+      e.preventDefault();
+    }
+  };
+
   return (
-    <div ref={focusRef} {...focusProps} className="flex items-center gap-4 mb-4">
+    <div ref={focusRef} {...focusProps} onKeyDown={handleWrapperKeyDown} className="flex items-center gap-4 mb-4">
       <input
         ref={inputRef}
         type="text"
@@ -127,13 +142,13 @@ export function VODPage() {
 
       {/* Results */}
       {streamsLoading ? (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+        <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
           <SkeletonGrid count={12} aspectRatio="poster" />
         </div>
       ) : processedStreams.length === 0 ? (
         <EmptyState title="No movies found" message="Try adjusting your filters" icon="content" />
       ) : (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+        <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
           {processedStreams.map((movie) => (
             <ContentCard
               key={movie.stream_id}


### PR DESCRIPTION
## Summary
- Updated 17 grid definitions across 8 files to use denser columns (3→5→6→8→10) matching home page rail card sizes (~140-160px)
- Added `handleWrapperKeyDown` to 4 `FocusableSearchInput` components to forward keystrokes from spatial-nav wrapper div to actual `<input>` element
- Live channel grids use even denser columns (4→6→8→10→12) for smaller square cards

## Test plan
- [ ] Verify card grid density matches home page rails on desktop
- [ ] Verify search input works with both keyboard and D-pad navigation
- [ ] Test on Fire Stick — cards should be ~140-160px wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)