### PR TITLE
fix: invalidate history cache so Resume uses latest position

### DIFF
--- a/src/features/player/api.ts
+++ b/src/features/player/api.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@lib/api';
 import type { StreamUrlResponse, HistoryUpdateRequest } from '@shared/types/api';
 
@@ -15,11 +15,15 @@ export function useStreamUrl(type: string, id: string) {
 }
 
 export function useUpdateHistory() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ contentId, ...data }: HistoryUpdateRequest & { contentId: string }) =>
       api(`/history/${contentId}`, {
         method: 'PUT',
         body: JSON.stringify(data),
       }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['history'] });
+    },
   });
 }


### PR DESCRIPTION
## Summary
- `useUpdateHistory()` now invalidates the `['history']` React Query cache on success
- Fixes Resume button using stale progress after Start Over playback
- Also fixes ContinueWatching rail showing outdated progress

## Test plan
- [ ] Open a movie with saved progress (Resume + Start Over visible)
- [ ] Click Start Over, watch 30+ seconds, close player
- [ ] Click Resume — should resume from where you just stopped
- [ ] Check ContinueWatching rail on Home page shows updated progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)