### PR TITLE
fix: add mpegts.js for live TV playback when provider serves raw .ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tanstack/react-virtual": "^3.11.0",
         "framer-motion": "^11.15.0",
         "hls.js": "^1.5.17",
+        "mpegts.js": "^1.8.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.0",
@@ -4020,6 +4021,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -5353,6 +5360,16 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
       "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
       "license": "MIT"
+    },
+    "node_modules/mpegts.js": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mpegts.js/-/mpegts.js-1.8.0.tgz",
+      "integrity": "sha512-ZtujqtmTjWgcDDkoOnLvrOKUTO/MKgLHM432zGDI8oPaJ0S+ebPxg1nEpDpLw6I7KmV/GZgUIrfbWi3qqEircg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "es6-promise": "^4.2.5",
+        "webworkify-webpack": "github:xqq/webworkify-webpack"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8140,6 +8157,11 @@
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webworkify-webpack": {
+      "version": "2.1.5",
+      "resolved": "git+ssh://git@github.com/xqq/webworkify-webpack.git#24d1e719b4a6cac37a518b2bb10fe124527ef4ef",
       "license": "MIT"
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-virtual": "^3.11.0",
     "framer-motion": "^11.15.0",
     "hls.js": "^1.5.17",
+    "mpegts.js": "^1.8.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.0",

--- a/src/features/player/api.ts
+++ b/src/features/player/api.ts
@@ -1,17 +1,49 @@
+import { useState, useEffect } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@lib/api';
 import type { StreamUrlResponse, HistoryUpdateRequest } from '@shared/types/api';
 
 export function useStreamUrl(type: string, id: string) {
   const enabled = !!type && !!id;
-  const data: StreamUrlResponse | undefined = enabled
-    ? {
-        url: `/api/stream/${type}/${id}`,
-        format: type === 'live' ? 'm3u8' : 'mp4',
-        isLive: type === 'live',
-      }
-    : undefined;
-  return { data, isLoading: false, error: null };
+  const [data, setData] = useState<StreamUrlResponse | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setData(undefined);
+      return;
+    }
+
+    const url = `/api/stream/${type}/${id}`;
+
+    if (type !== 'live') {
+      setData({ url, format: 'mp4', isLive: false });
+      return;
+    }
+
+    // Probe format via HEAD request for live streams
+    let cancelled = false;
+    setIsLoading(true);
+
+    fetch(url, { method: 'HEAD', credentials: 'include' })
+      .then((res) => {
+        if (cancelled) return;
+        const format = res.headers.get('x-stream-format') || 'm3u8';
+        setData({ url, format, isLive: true });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // Default to m3u8 on probe failure — backend GET will handle fallback
+        setData({ url, format: 'm3u8', isLive: true });
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [type, id, enabled]);
+
+  return { data, isLoading, error: null };
 }
 
 export function useUpdateHistory() {

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useCallback, useState, forwardRef, useImperativeHandle } from 'react';
 import type HlsType from 'hls.js';
+import type mpegtsType from 'mpegts.js';
 
 export interface QualityLevel {
   index: number;
@@ -38,13 +39,21 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
   ) {
     const videoRef = useRef<HTMLVideoElement>(null);
     const hlsRef = useRef<HlsType | null>(null);
+    const mpegtsRef = useRef<mpegtsType.Player | null>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const [isReady, setIsReady] = useState(false);
 
-    const destroyHls = useCallback(() => {
+    const destroyPlayers = useCallback(() => {
       if (hlsRef.current) {
         hlsRef.current.destroy();
         hlsRef.current = null;
+      }
+      if (mpegtsRef.current) {
+        mpegtsRef.current.pause();
+        mpegtsRef.current.unload();
+        mpegtsRef.current.detachMediaElement();
+        mpegtsRef.current.destroy();
+        mpegtsRef.current = null;
       }
     }, []);
 
@@ -116,7 +125,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
 
       const startDirectPlayback = () => {
         if (cancelled) return;
-        destroyHls();
+        destroyPlayers();
         video.src = url;
         video.onloadeddata = () => {
           if (cancelled) return;
@@ -139,7 +148,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
 
       const startHlsPlayback = (Hls: typeof HlsType) => {
         if (cancelled) return;
-        destroyHls();
+        destroyPlayers();
         const hls = new Hls({
           enableWorker: true,
           capLevelToPlayerSize: true,
@@ -221,7 +230,57 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         }
       };
 
-      if (isHls) {
+      const startMpegtsPlayback = async () => {
+        if (cancelled) return;
+        destroyPlayers();
+        try {
+          const mpegts = await import('mpegts.js');
+          if (cancelled || !mpegts.default.isSupported()) {
+            startDirectPlayback();
+            return;
+          }
+          const player = mpegts.default.createPlayer({
+            type: 'mpegts',
+            isLive: true,
+            url,
+          }, {
+            enableWorker: true,
+            enableStashBuffer: false,
+            stashInitialSize: 128 * 1024, // 128KB
+            liveBufferLatencyChasing: true,
+            liveBufferLatencyMaxLatency: 3,
+            liveBufferLatencyMinRemain: 0.5,
+          });
+          mpegtsRef.current = player;
+          player.attachMediaElement(video);
+          player.load();
+
+          player.on(mpegts.default.Events.ERROR, () => {
+            if (cancelled) return;
+            if (!fallbackAttempted) {
+              fallbackAttempted = true;
+              startDirectPlayback();
+            } else {
+              onError?.('Channel unavailable');
+            }
+          });
+
+          video.onloadeddata = () => {
+            if (cancelled) return;
+            setIsReady(true);
+          };
+          if (autoPlay) player.play();
+        } catch {
+          if (!cancelled) startDirectPlayback();
+        }
+      };
+
+      const isTs = format === 'ts';
+
+      if (isTs) {
+        // MPEG-TS stream — use mpegts.js
+        startMpegtsPlayback();
+      } else if (isHls) {
         // Check native HLS support first (Safari), otherwise dynamic-import hls.js
         if (video.canPlayType('application/vnd.apple.mpegurl')) {
           video.src = url;
@@ -232,17 +291,18 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           initHls();
         }
       } else {
-        // Direct playback for .ts, .mp4, or non-HLS streams
+        // Direct playback for .mp4 or other formats
         startDirectPlayback();
       }
 
       return () => {
         cancelled = true;
-        destroyHls();
+        destroyPlayers();
         video.onloadeddata = null;
         video.onerror = null;
       };
-    }, [url, format, isLive, autoPlay, startTime, onError, onQualityLevelsReady, destroyHls]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [url, format, isLive, autoPlay, startTime, onError, onQualityLevelsReady, destroyPlayers]);
 
     useEffect(() => {
       const video = videoRef.current;


### PR DESCRIPTION
## Summary
- Frontend now probes stream format via HEAD request before initializing player
- Reads `X-Stream-Format` header to determine `m3u8` vs `ts` format
- Added `mpegts.js` (dynamic import, 274KB chunk) for MPEG-TS stream playback
- Low-latency config: buffer chasing, 128KB stash, 3s max latency
- Falls back to m3u8 if probe fails (backend GET handler also has .ts fallback)
- Companion PR: streamvault-backend fix/live-stream-ts-fallback

## Test plan
- [ ] Open StreamVault, click a live Telugu channel
- [ ] Video should play via mpegts.js (check Network tab for mpegts chunk load)
- [ ] VOD playback still uses hls.js/native (unaffected)
- [ ] Test on Fire Stick: live TV plays in TWA/PWA

🤖 Generated with [Claude Code](https://claude.com/claude-code)