### PR TITLE
fix: default live format to 'ts', remove HEAD probe

### DIFF
--- a/src/features/player/api.ts
+++ b/src/features/player/api.ts
@@ -1,49 +1,17 @@
-import { useState, useEffect } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@lib/api';
 import type { StreamUrlResponse, HistoryUpdateRequest } from '@shared/types/api';
 
 export function useStreamUrl(type: string, id: string) {
   const enabled = !!type && !!id;
-  const [data, setData] = useState<StreamUrlResponse | undefined>(undefined);
-  const [isLoading, setIsLoading] = useState(false);
-
-  useEffect(() => {
-    if (!enabled) {
-      setData(undefined);
-      return;
-    }
-
-    const url = `/api/stream/${type}/${id}`;
-
-    if (type !== 'live') {
-      setData({ url, format: 'mp4', isLive: false });
-      return;
-    }
-
-    // Probe format via HEAD request for live streams
-    let cancelled = false;
-    setIsLoading(true);
-
-    fetch(url, { method: 'HEAD', credentials: 'include' })
-      .then((res) => {
-        if (cancelled) return;
-        const format = res.headers.get('x-stream-format') || 'm3u8';
-        setData({ url, format, isLive: true });
-      })
-      .catch(() => {
-        if (cancelled) return;
-        // Default to m3u8 on probe failure — backend GET will handle fallback
-        setData({ url, format: 'm3u8', isLive: true });
-      })
-      .finally(() => {
-        if (!cancelled) setIsLoading(false);
-      });
-
-    return () => { cancelled = true; };
-  }, [type, id, enabled]);
-
-  return { data, isLoading, error: null };
+  const data: StreamUrlResponse | undefined = enabled
+    ? {
+        url: `/api/stream/${type}/${id}`,
+        format: type === 'live' ? 'ts' : 'mp4',
+        isLive: type === 'live',
+      }
+    : undefined;
+  return { data, isLoading: false, error: null };
 }
 
 export function useUpdateHistory() {


### PR DESCRIPTION
## Summary
- HEAD probe caused 504 timeout (Xtream hangs on .m3u8)
- Reverted to synchronous format: live→'ts' (mpegts.js), VOD→'mp4'
- No async probe needed — simpler, faster

## Test plan
- [ ] Live TV plays immediately via mpegts.js (no spinner/timeout)
- [ ] No HEAD request in Network tab
- [ ] VOD still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)