### PR TITLE
fix: deduplicate series across OTT platforms

### DIFF
--- a/src/features/series/api.ts
+++ b/src/features/series/api.ts
@@ -163,6 +163,7 @@ export function useSeriesByLanguage(language: string) {
   const allSeries = useMemo<SeriesWithChannel[]>(() => {
     const result: SeriesWithChannel[] = [];
     const seen = new Set<number>();
+    const seenNames = new Set<string>();
     const isAll = language.toLowerCase() === 'all';
 
     queries.forEach((q, idx) => {
@@ -180,7 +181,12 @@ export function useSeriesByLanguage(language: string) {
           if (!item.name.toLowerCase().includes(language.toLowerCase())) continue;
         }
 
+        // Name-based dedup: same series listed on multiple OTT platforms with different IDs
+        const normalizedName = item.name.replace(/\s*\([^)]*\)\s*$/g, '').trim().toLowerCase();
+        if (seenNames.has(normalizedName)) continue;
+
         seen.add(item.series_id);
+        seenNames.add(normalizedName);
         result.push({
           ...item,
           name: isMulti ? stripLanguageTag(item.name) : item.name,


### PR DESCRIPTION
## Summary
- Same series (e.g., Gyaarah Gyaarah) listed on multiple OTT platforms (Disney+, ZEE5) with different `series_id` values caused duplicates
- Added name-based deduplication alongside existing `series_id` check
- Normalizes names (lowercase + strip language tag) before comparing

## Test plan
- [ ] Load Series page → ZEE5 tab → confirm "Gyaarah Gyaarah" appears only once
- [ ] Check "All" tab — duplicate counts reduced
- [ ] Telugu-only channels (Star Maa, Zee Telugu) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)