### PR TITLE
feat: reorder series tabs + add latest content rails

### DIFF
--- a/src/features/language/components/MoviesTabContent.tsx
+++ b/src/features/language/components/MoviesTabContent.tsx
@@ -172,6 +172,14 @@ export function MoviesTabContent({ language, lang }: MoviesTabContentProps) {
 
   const hasActiveFilters = !!debouncedSearch || activeCategory !== null || sortKey !== 'name_asc';
 
+  // Latest movies rail: top 20 by added date
+  const latestMovies = useMemo(() => {
+    if (!allMovies.length) return [];
+    return [...allMovies]
+      .sort((a, b) => parseInt(b.added || '0', 10) - parseInt(a.added || '0', 10))
+      .slice(0, 20);
+  }, [allMovies]);
+
   // Category chips from rails data
   const categoryChips = useMemo(
     () =>
@@ -276,6 +284,28 @@ export function MoviesTabContent({ language, lang }: MoviesTabContentProps) {
           {railsLoading && (
             <ContentRail title="Loading..." isLoading={true}>
               <div />
+            </ContentRail>
+          )}
+          {/* Latest Movies rail */}
+          {latestMovies.length > 0 && !railsLoading && (
+            <ContentRail title="Latest Movies">
+              {latestMovies.map((item) => (
+                <FocusableCard
+                  key={item.stream_id}
+                  focusKey={`vod-latest-${item.stream_id}`}
+                  image={item.stream_icon}
+                  title={item.name}
+                  subtitle={item.rating ? `⭐ ${item.rating}` : undefined}
+                  isNew={isNewContent(item.added)}
+                  aspectRatio="poster"
+                  onClick={() =>
+                    navigate({
+                      to: '/vod/$vodId',
+                      params: { vodId: String(item.stream_id) },
+                    })
+                  }
+                />
+              ))}
             </ContentRail>
           )}
           {movieRails.map((rail) => (

--- a/src/features/language/components/SeriesTabContent.tsx
+++ b/src/features/language/components/SeriesTabContent.tsx
@@ -165,6 +165,18 @@ export function SeriesTabContent({ language }: SeriesTabContentProps) {
 
   const totalCount = allSeries.length;
 
+  // Recently added rail: top 20 by last_modified
+  const recentSeries = useMemo(() => {
+    if (!allSeries.length) return [];
+    return [...allSeries]
+      .sort((a, b) => {
+        const aTime = parseInt(a.last_modified || '0', 10);
+        const bTime = parseInt(b.last_modified || '0', 10);
+        return bTime - aTime;
+      })
+      .slice(0, 20);
+  }, [allSeries]);
+
   // Rails mode: group series by channel
   const seriesRails = useMemo(() => {
     if (!allSeries.length) return [];
@@ -271,6 +283,29 @@ export function SeriesTabContent({ language }: SeriesTabContentProps) {
       ) : !hasActiveFilters ? (
         /* Rails mode */
         <div className="space-y-8">
+          {/* Recently Added rail */}
+          {recentSeries.length > 0 && (
+            <ContentRail title="Recently Added">
+              {recentSeries.map((item) => (
+                <FocusableCard
+                  key={item.series_id}
+                  focusKey={`series-recent-${item.series_id}`}
+                  image={item.cover}
+                  title={item.name}
+                  subtitle={item.genre || undefined}
+                  isNew={isNewContent(item.last_modified)}
+                  aspectRatio="poster"
+                  onClick={() =>
+                    navigate({
+                      to: '/series/$seriesId',
+                      params: { seriesId: String(item.series_id) },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    } as any)
+                  }
+                />
+              ))}
+            </ContentRail>
+          )}
           {seriesRails.map((rail) => (
             <ContentRail key={rail.channelId} title={rail.channelName}>
               {rail.items.map((item) => (

--- a/src/features/series/api.ts
+++ b/src/features/series/api.ts
@@ -6,13 +6,19 @@ import type { XtreamCategory, XtreamSeriesItem, XtreamSeriesInfo } from '@shared
 // ── Channel-to-language mapping (fallback until category parser is rewritten) ──
 
 const SERIES_CHANNEL_LANGUAGE: Record<string, string> = {
-  // Telugu TV channels
-  '453': 'Telugu', // STAR MAA
+  // Telugu TV channels (ordered by popularity)
   '455': 'Telugu', // ZEE TELUGU
-  '494': 'Telugu', // GEMINI
-  '493': 'Telugu', // ETV
-  '552': 'Telugu', // SONY TELUGU
+  '453': 'Telugu', // STAR MAA
   '469': 'Telugu', // AHA
+  '493': 'Telugu', // ETV
+  '494': 'Telugu', // GEMINI
+  '552': 'Telugu', // SONY TELUGU
+  // OTT Platforms (mixed-language — filtered by series name)
+  '104': 'Multi', // ZEE5+ALT BALAJI
+  '105': 'Multi', // SONY LIV
+  '106': 'Multi', // NETFLIX
+  '102': 'Multi', // DISNEY+ HOTSTAR
+  '310': 'Multi', // JIO CINEMA
   // Hindi TV channels
   '442': 'Hindi', // COLORS HINDI
   '443': 'Hindi', // SONY (SET)
@@ -26,12 +32,6 @@ const SERIES_CHANNEL_LANGUAGE: Record<string, string> = {
   '161': 'Hindi', // HINDI TV SERIES
   '276': 'Hindi', // INDIAN Reality Shows
   '200': 'Hindi', // BIGG BOSS OTT
-  // OTT Platforms (mixed-language — filtered by series name)
-  '102': 'Multi', // DISNEY+ HOTSTAR
-  '104': 'Multi', // ZEE5+ALT BALAJI
-  '105': 'Multi', // SONY LIV
-  '106': 'Multi', // NETFLIX
-  '310': 'Multi', // JIO CINEMA
 };
 
 const CHANNEL_NAMES: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Reorder series category tabs: Telugu channels first (Zee Telugu, Star Maa, Aha, ETV, Gemini, Sony Telugu), then OTT (ZEE5, Sony LIV, Netflix, Disney+ Hotstar, Jio Cinema), then Hindi
- Add "Recently Added" horizontal rail at top of Series page (sorted by last_modified)
- Add "Latest Movies" horizontal rail at top of Movies page (sorted by added date)
- Both rails show top 20 items, only visible in rails mode (hidden when filters active)
- No new API calls — reuses existing fetched data

## Test plan
- [ ] Open Series page → verify tab order: All, Zee Telugu, Star Maa, Aha, ETV, Gemini, Sony Telugu, ZEE5, ...
- [ ] Series page shows "Recently Added" rail at the top with newest series
- [ ] Movies page shows "Latest Movies" rail at the top with newest movies
- [ ] Rails disappear when search/filter/sort is active
- [ ] D-pad navigation works on new rails

🤖 Generated with [Claude Code](https://claude.com/claude-code)