### PR TITLE
fix: live TV playback — CSP blob: + mpegts.js fixes

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -94,7 +94,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://api.fontshare.com; img-src 'self' data: https:; font-src 'self' https://api.fontshare.com https://cdn.fontshare.com; connect-src 'self' https:; media-src 'self' http: https:; worker-src 'self'; manifest-src 'self'; frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://api.fontshare.com; img-src 'self' data: https:; font-src 'self' https://api.fontshare.com https://cdn.fontshare.com; connect-src 'self' https:; media-src 'self' blob: http: https:; worker-src 'self' blob:; manifest-src 'self'; frame-ancestors 'self';" always;
 
     server_tokens off;
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 // Minimal SW to enable PWA install on Samsung TV, Fire Stick, mobile, etc.
 // Does NOT cache aggressively — streaming content should always be live.
 
-const CACHE_NAME = 'streamvault-shell-v7';
+const CACHE_NAME = 'streamvault-shell-v8';
 const SHELL_ASSETS = [
   '/',
   '/manifest.json',

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -3,4 +3,4 @@ add_header X-Content-Type-Options "nosniff" always;
 add_header X-XSS-Protection "1; mode=block" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Cross-Origin-Opener-Policy "same-origin" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://api.fontshare.com; img-src 'self' data: https:; font-src 'self' https://api.fontshare.com https://cdn.fontshare.com; connect-src 'self' https:; media-src 'self' http: https:; worker-src 'self'; manifest-src 'self'; frame-ancestors 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://api.fontshare.com; img-src 'self' data: https:; font-src 'self' https://api.fontshare.com https://cdn.fontshare.com; connect-src 'self' https:; media-src 'self' blob: http: https:; worker-src 'self' blob:; manifest-src 'self'; frame-ancestors 'self';" always;

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -244,7 +244,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
             isLive: true,
             url,
           }, {
-            enableWorker: true,
+            enableWorker: false, // CSP worker-src blocks Blob URL workers; main-thread demux is fine
             enableStashBuffer: false,
             stashInitialSize: 128 * 1024, // 128KB
             liveBufferLatencyChasing: true,


### PR DESCRIPTION
## Summary
- Add `blob:` to `media-src` and `worker-src` CSP directives in both `nginx.conf` and `security-headers.conf`
- Set mpegts.js `enableWorker: false` to avoid CSP blob worker restrictions
- Bump service worker cache to v8

## Root Cause
Chrome MediaSource Extensions creates `blob:` URLs for `<video>` elements. The CSP `media-src` was missing `blob:`, causing Chrome to silently block playback. mpegts.js loaded and connected but the video source was rejected by CSP.

## Test plan
- [ ] Hard refresh streamvault.srinivaskotha.uk, play a live Telugu channel
- [ ] Verify no CSP errors in console
- [ ] Verify stream plays with audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)