### PR TITLE
feat: player improvements — subtitles, live edge, seek debounce, quality fix

### DIFF
--- a/src/features/player/__tests__/usePlayerKeyboard.test.ts
+++ b/src/features/player/__tests__/usePlayerKeyboard.test.ts
@@ -22,6 +22,8 @@ function createMockPlayer(overrides: Partial<{ paused: boolean; currentTime: num
       togglePiP: vi.fn().mockResolvedValue(undefined),
       seek: vi.fn(),
       setQuality: vi.fn(),
+      setSubtitleTrack: vi.fn(),
+      seekToLiveEdge: vi.fn(),
     } satisfies VideoPlayerHandle,
   } as React.RefObject<VideoPlayerHandle | null>;
 }

--- a/src/features/player/components/PlayerControls.tsx
+++ b/src/features/player/components/PlayerControls.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback } from 'react';
-import type { QualityLevel, VideoPlayerHandle } from './VideoPlayer';
+import type { QualityLevel, SubtitleTrack, VideoPlayerHandle } from './VideoPlayer';
 import type React from 'react';
 import { formatDuration } from '@shared/utils/formatDuration';
 import { isTVMode } from '@shared/utils/isTVMode';
@@ -174,6 +174,45 @@ function QualityDropdownItems({
   );
 }
 
+/** Subtitle dropdown items — only mounted when dropdown is open (conditional render pattern) */
+function SubtitleDropdownItems({
+  subtitleTracks,
+  currentSubtitle,
+  onSubtitleChange,
+  onClose,
+}: {
+  subtitleTracks: SubtitleTrack[];
+  currentSubtitle: number;
+  onSubtitleChange: (index: number) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="absolute bottom-full right-0 mb-2 bg-surface border border-border rounded-lg overflow-hidden shadow-card min-w-[140px]">
+      <FocusableButton
+        id="player-subtitle-off"
+        onClick={() => { onSubtitleChange(-1); onClose(); }}
+        className={`w-full text-left px-3 py-1.5 text-xs transition-colors ${
+          currentSubtitle === -1 ? 'bg-teal/15 text-teal' : 'text-text-secondary hover:bg-surface-raised'
+        }`}
+      >
+        Off
+      </FocusableButton>
+      {subtitleTracks.map((track) => (
+        <FocusableButton
+          id={`player-subtitle-${track.index}`}
+          key={track.index}
+          onClick={() => { onSubtitleChange(track.index); onClose(); }}
+          className={`w-full text-left px-3 py-1.5 text-xs transition-colors ${
+            currentSubtitle === track.index ? 'bg-teal/15 text-teal' : 'text-text-secondary hover:bg-surface-raised'
+          }`}
+        >
+          {track.label}{track.lang ? ` (${track.lang})` : ''}
+        </FocusableButton>
+      ))}
+    </div>
+  );
+}
+
 interface PlayerControlsProps {
   playerRef: React.RefObject<VideoPlayerHandle | null>;
   isPlaying: boolean;
@@ -183,6 +222,11 @@ interface PlayerControlsProps {
   qualityLevels: QualityLevel[];
   currentQuality: number;
   onQualityChange: (index: number) => void;
+  subtitleTracks?: SubtitleTrack[];
+  currentSubtitle?: number;
+  onSubtitleChange?: (index: number) => void;
+  atLiveEdge?: boolean;
+  onSeekToLiveEdge?: () => void;
   volume: number;
   isMuted: boolean;
   onVolumeChange: (v: number) => void;
@@ -203,6 +247,11 @@ export function PlayerControls({
   qualityLevels,
   currentQuality,
   onQualityChange,
+  subtitleTracks = [],
+  currentSubtitle = -1,
+  onSubtitleChange,
+  atLiveEdge = true,
+  onSeekToLiveEdge,
   volume,
   isMuted,
   onVolumeChange,
@@ -214,6 +263,7 @@ export function PlayerControls({
   visible = true,
 }: PlayerControlsProps) {
   const [showQuality, setShowQuality] = useState(false);
+  const [showSubtitles, setShowSubtitles] = useState(false);
   const progressRef = useRef<HTMLDivElement>(null);
 
   // Spatial Navigation: controls container
@@ -340,19 +390,54 @@ export function PlayerControls({
               {formatDuration(Math.floor(currentTime))} / {formatDuration(Math.floor(duration))}
             </span>
           )}
-          {isLive && (
+          {isLive && atLiveEdge && (
             <span className="flex items-center gap-1 text-xs text-error ml-1">
               <span className="w-2 h-2 bg-error rounded-full animate-pulse" />
               LIVE
             </span>
           )}
+          {isLive && !atLiveEdge && (
+            <FocusableButton
+              id="player-go-live"
+              onClick={() => onSeekToLiveEdge?.()}
+              className="flex items-center gap-1 text-xs text-white/50 hover:text-white ml-1 px-2 py-1 rounded transition-colors"
+              title="Jump to live edge"
+            >
+              <span className="w-2 h-2 bg-white/40 rounded-full" />
+              Go Live
+            </FocusableButton>
+          )}
 
           <div className="flex-1" />
+
+          {/* Subtitles / CC */}
+          {subtitleTracks.length > 0 && onSubtitleChange && (
+            <div className="relative">
+              <FocusableButton
+                id="player-subtitle-toggle"
+                onClick={() => { setShowSubtitles(!showSubtitles); setShowQuality(false); }}
+                className={`p-1.5 transition-colors ${currentSubtitle !== -1 ? 'text-teal' : 'text-white/70 hover:text-white'}`}
+                title="Subtitles"
+              >
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M19 4H5c-1.11 0-2 .9-2 2v12c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-8 7H9.5v-.5h-2v3h2V13H11v1c0 .55-.45 1-1 1H7c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1h3c.55 0 1 .45 1 1v1zm7 0h-1.5v-.5h-2v3h2V13H18v1c0 .55-.45 1-1 1h-3c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1h3c.55 0 1 .45 1 1v1z" />
+                </svg>
+              </FocusableButton>
+              {showSubtitles && (
+                <SubtitleDropdownItems
+                  subtitleTracks={subtitleTracks}
+                  currentSubtitle={currentSubtitle}
+                  onSubtitleChange={onSubtitleChange}
+                  onClose={() => setShowSubtitles(false)}
+                />
+              )}
+            </div>
+          )}
 
           {/* Quality */}
           {qualityLevels.length > 1 && (
             <div className="relative">
-              <FocusableButton id="player-quality-toggle" onClick={() => setShowQuality(!showQuality)} className="p-1.5 text-white/70 hover:text-white transition-colors">
+              <FocusableButton id="player-quality-toggle" onClick={() => { setShowQuality(!showQuality); setShowSubtitles(false); }} className="p-1.5 text-white/70 hover:text-white transition-colors">
                 <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                   <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />

--- a/src/features/player/components/PlayerPage.tsx
+++ b/src/features/player/components/PlayerPage.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState, useCallback, useEffect } from 'react';
 import { useStreamUrl } from '../api';
-import { VideoPlayer, type VideoPlayerHandle, type QualityLevel } from './VideoPlayer';
+import { VideoPlayer, type VideoPlayerHandle, type QualityLevel, type SubtitleTrack } from './VideoPlayer';
 import { PlayerControls } from './PlayerControls';
 import { PlayerOSD, type OSDAction } from './PlayerOSD';
 import { usePlayerKeyboard } from '../hooks/usePlayerKeyboard';
@@ -44,6 +44,9 @@ export function PlayerPage({
   const [duration, setDuration] = useState(0);
   const [qualityLevels, setQualityLevels] = useState<QualityLevel[]>([]);
   const [currentQuality, setCurrentQuality] = useState(-1);
+  const [subtitleTracks, setSubtitleTracks] = useState<SubtitleTrack[]>([]);
+  const [currentSubtitle, setCurrentSubtitle] = useState(-1);
+  const [atLiveEdge, setAtLiveEdge] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [osdAction, setOsdAction] = useState<OSDAction | null>(null);
 
@@ -79,6 +82,11 @@ export function PlayerPage({
     playerRef.current?.setQuality(index);
   }, []);
 
+  const handleSubtitleChange = useCallback((index: number) => {
+    setCurrentSubtitle(index);
+    playerRef.current?.setSubtitleTrack(index);
+  }, []);
+
   const handleVolumeUp = useCallback(() => setVolume(Math.min(1, volume + 0.1)), [volume, setVolume]);
   const handleVolumeDown = useCallback(() => setVolume(Math.max(0, volume - 0.1)), [volume, setVolume]);
 
@@ -109,6 +117,13 @@ export function PlayerPage({
     });
     showControls();
   }, [showControls]);
+
+  // Clean up controls timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (controlsTimeoutRef.current) clearTimeout(controlsTimeoutRef.current);
+    };
+  }, []);
 
   // Show controls when paused
   useEffect(() => {
@@ -236,6 +251,8 @@ export function PlayerPage({
           onEnded={onNext}
           onError={setError}
           onQualityLevelsReady={setQualityLevels}
+          onSubtitleTracksReady={setSubtitleTracks}
+          onLiveEdgeChange={setAtLiveEdge}
           onPlayStateChange={setIsPlaying}
         />
         <PlayerControls
@@ -251,6 +268,11 @@ export function PlayerPage({
           isMuted={isMuted}
           onVolumeChange={setVolume}
           onMuteToggle={toggleMute}
+          subtitleTracks={subtitleTracks}
+          currentSubtitle={currentSubtitle}
+          onSubtitleChange={handleSubtitleChange}
+          atLiveEdge={atLiveEdge}
+          onSeekToLiveEdge={() => playerRef.current?.seekToLiveEdge()}
           hasNext={hasNext}
           hasPrev={hasPrev}
           onNext={onNext}

--- a/src/features/player/components/VideoPlayer.tsx
+++ b/src/features/player/components/VideoPlayer.tsx
@@ -10,11 +10,19 @@ export interface QualityLevel {
   label: string;
 }
 
+export interface SubtitleTrack {
+  index: number;
+  lang: string;
+  label: string;
+}
+
 export interface VideoPlayerHandle {
   play: () => void;
   pause: () => void;
   seek: (time: number) => void;
   setQuality: (index: number) => void;
+  setSubtitleTrack: (index: number) => void;
+  seekToLiveEdge: () => void;
   getVideo: () => HTMLVideoElement | null;
   toggleFullscreen: () => void;
   togglePiP: () => Promise<void>;
@@ -30,18 +38,21 @@ interface VideoPlayerProps {
   onEnded?: () => void;
   onError?: (error: string) => void;
   onQualityLevelsReady?: (levels: QualityLevel[]) => void;
+  onSubtitleTracksReady?: (tracks: SubtitleTrack[]) => void;
+  onLiveEdgeChange?: (atLiveEdge: boolean) => void;
   onPlayStateChange?: (playing: boolean) => void;
 }
 
 export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
   function VideoPlayer(
-    { url, isLive, format, autoPlay = true, startTime = 0, onTimeUpdate, onEnded, onError, onQualityLevelsReady, onPlayStateChange },
+    { url, isLive, format, autoPlay = true, startTime = 0, onTimeUpdate, onEnded, onError, onQualityLevelsReady, onSubtitleTracksReady, onLiveEdgeChange, onPlayStateChange },
     ref,
   ) {
     const videoRef = useRef<HTMLVideoElement>(null);
     const hlsRef = useRef<HlsType | null>(null);
     const mpegtsRef = useRef<mpegtsType.Player | null>(null);
     const containerRef = useRef<HTMLDivElement>(null);
+    const lastAtLiveEdgeRef = useRef(true);
     const [isReady, setIsReady] = useState(false);
 
     const destroyPlayers = useCallback(() => {
@@ -65,7 +76,19 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         if (videoRef.current) videoRef.current.currentTime = time;
       },
       setQuality: (index: number) => {
-        if (hlsRef.current) hlsRef.current.currentLevel = index;
+        if (hlsRef.current) hlsRef.current.nextLevel = index;
+      },
+      setSubtitleTrack: (index: number) => {
+        if (hlsRef.current) hlsRef.current.subtitleTrack = index;
+      },
+      seekToLiveEdge: () => {
+        const video = videoRef.current;
+        if (!video) return;
+        if (video.seekable.length) {
+          video.currentTime = video.seekable.end(video.seekable.length - 1) - 2;
+        } else if (hlsRef.current?.liveSyncPosition) {
+          video.currentTime = hlsRef.current.liveSyncPosition;
+        }
       },
       getVideo: () => videoRef.current,
       toggleFullscreen: () => {
@@ -162,10 +185,10 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
             lowLatencyMode: true,
             liveSyncDuration: 3,
             liveMaxLatencyDuration: 10,
-            liveBackBufferLength: 30,
-            backBufferLength: 30,
+            liveBackBufferLength: isTVMode ? 15 : 30,
+            backBufferLength: isTVMode ? 15 : 30,
           } : {
-            backBufferLength: 60,
+            backBufferLength: isTVMode ? 20 : 60,
           }),
         });
         hlsRef.current = hls;
@@ -187,6 +210,17 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           }
           if (startTime > 0 && !isLive) video.currentTime = startTime;
           if (autoPlay) video.play().catch(() => {});
+        });
+
+        // Subtitle track discovery
+        hls.on(Hls.Events.SUBTITLE_TRACKS_UPDATED, () => {
+          if (cancelled || !onSubtitleTracksReady) return;
+          const tracks: SubtitleTrack[] = hls.subtitleTracks.map((t, i) => ({
+            index: i,
+            lang: t.lang || '',
+            label: t.name || `Track ${i + 1}`,
+          }));
+          onSubtitleTracksReady(tracks);
         });
 
         hls.on(Hls.Events.ERROR, (_event, data) => {
@@ -303,7 +337,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         video.onerror = null;
       };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [url, format, isLive, autoPlay, startTime, onError, onQualityLevelsReady, destroyPlayers]);
+    }, [url, format, isLive, autoPlay, startTime, onError, onQualityLevelsReady, onSubtitleTracksReady, destroyPlayers]);
 
     useEffect(() => {
       const video = videoRef.current;
@@ -312,6 +346,28 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       video.addEventListener('timeupdate', handler);
       return () => video.removeEventListener('timeupdate', handler);
     }, [onTimeUpdate]);
+
+    // Live edge detection — fires onLiveEdgeChange when user seeks away from or back to live edge
+    useEffect(() => {
+      const video = videoRef.current;
+      if (!video || !isLive || !onLiveEdgeChange) return;
+      const handler = () => {
+        let atEdge = true;
+        if (video.seekable.length) {
+          const liveEdge = video.seekable.end(video.seekable.length - 1);
+          atEdge = liveEdge - video.currentTime < 15;
+        } else if (hlsRef.current?.liveSyncPosition) {
+          atEdge = hlsRef.current.liveSyncPosition - video.currentTime < 15;
+        }
+        // Only fire callback when state actually changes
+        if (atEdge !== lastAtLiveEdgeRef.current) {
+          lastAtLiveEdgeRef.current = atEdge;
+          onLiveEdgeChange(atEdge);
+        }
+      };
+      video.addEventListener('timeupdate', handler);
+      return () => video.removeEventListener('timeupdate', handler);
+    }, [isLive, onLiveEdgeChange]);
 
     useEffect(() => {
       const video = videoRef.current;

--- a/src/features/player/hooks/usePlayerKeyboard.ts
+++ b/src/features/player/hooks/usePlayerKeyboard.ts
@@ -40,6 +40,15 @@ export function usePlayerKeyboard({
   onOSD,
 }: UsePlayerKeyboardOptions) {
   const holdStateRef = useRef<SeekHoldState | null>(null);
+  const seekDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /** Debounced seek — prevents rapid D-pad presses from causing stutter on Fire TV */
+  const debouncedSeek = (time: number) => {
+    if (seekDebounceRef.current) clearTimeout(seekDebounceRef.current);
+    seekDebounceRef.current = setTimeout(() => {
+      playerRef.current?.seek(time);
+    }, 80);
+  };
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -108,7 +117,7 @@ export function usePlayerKeyboard({
               accumulatedSeek: 10 * direction,
             };
             const newTime = video.currentTime + 10 * direction;
-            playerRef.current?.seek(Math.max(0, Math.min(video.duration, newTime)));
+            debouncedSeek(Math.max(0, Math.min(video.duration, newTime)));
             onOSD?.({
               type: direction > 0 ? 'seek-forward' : 'seek-back',
               timestamp: Date.now(),
@@ -123,7 +132,7 @@ export function usePlayerKeyboard({
               hold.accumulatedSeek += seekAmount;
 
               const newTime = video.currentTime + seekAmount;
-              playerRef.current?.seek(Math.max(0, Math.min(video.duration, newTime)));
+              debouncedSeek(Math.max(0, Math.min(video.duration, newTime)));
 
               if (speed > 1) {
                 onOSD?.({
@@ -209,6 +218,7 @@ export function usePlayerKeyboard({
     return () => {
       window.removeEventListener('keydown', handleKeyDown, { capture: true });
       window.removeEventListener('keyup', handleKeyUp, { capture: true });
+      if (seekDebounceRef.current) clearTimeout(seekDebounceRef.current);
     };
   }, [playerRef, isLive, onNext, onPrev, onMuteToggle, onVolumeUp, onVolumeDown, onClose, onOSD]);
 }


### PR DESCRIPTION
## Summary
- **Subtitle/CC track switching**: Reads HLS subtitle tracks, CC button in controls, dropdown with Off + per-track selection
- **Live edge detection + Go Live**: Detects when user is behind live edge (15s threshold), shows clickable "Go Live" button replacing static LIVE badge
- **Seek debounce (80ms)**: Prevents rapid D-pad presses from causing stutter on Fire TV
- **Quality switch fix**: `hls.nextLevel` instead of `hls.currentLevel` — switches at segment boundary (no freeze/glitch)
- **TV buffer reduction**: `backBufferLength: 20` (VOD) / `15` (live) on TV mode vs 60/30 on desktop — prevents OOM on Fire Stick
- **Bug fix**: `controlsTimeoutRef` cleanup on unmount (memory leak)

Cherry-picked from a proposed monolithic player rewrite. Kept existing modular architecture intact.

## Test plan
- [ ] Play a live channel → verify red LIVE badge shows
- [ ] VOD: rapid D-pad left/right → verify no stutter (debounce working)
- [ ] Play stream with CC tracks → verify CC button appears → toggle → verify rendering
- [ ] Quality switch during playback → verify no freeze/black frame
- [ ] Long Fire TV session (>30 min) → verify no OOM crash
- [ ] All existing features: hold-to-seek, series nav, resume, PiP, OSD

🤖 Generated with [Claude Code](https://claude.com/claude-code)