### PR TITLE
fix: TV back button closes player reliably on Fire Stick

### DIFF
--- a/src/features/player/hooks/usePlayerKeyboard.ts
+++ b/src/features/player/hooks/usePlayerKeyboard.ts
@@ -165,6 +165,18 @@ export function usePlayerKeyboard({
         return;
       }
 
+      // Android/Fire TV back button (keyCode 4) — handle before switch
+      if (e.keyCode === 4) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!isTVMode && document.fullscreenElement) {
+          document.exitFullscreen();
+        } else if (onClose) {
+          onClose();
+        }
+        return;
+      }
+
       switch (e.key) {
         case ' ':
         case 'k': {
@@ -197,7 +209,7 @@ export function usePlayerKeyboard({
         case 'GoBack': // Samsung TV Back Key
           e.preventDefault();
           e.stopPropagation();
-          if (document.fullscreenElement) {
+          if (!isTVMode && document.fullscreenElement) {
             document.exitFullscreen();
           } else if (onClose) {
             onClose();

--- a/src/shared/hooks/useBackNavigation.ts
+++ b/src/shared/hooks/useBackNavigation.ts
@@ -24,7 +24,7 @@ export function useBackNavigation() {
       // Don't intercept when player is active — usePlayerKeyboard handles it
       if (usePlayerStore.getState().currentStreamId) return;
 
-      if (e.key === 'Escape' || e.key === 'Backspace') {
+      if (e.key === 'Escape' || e.key === 'Backspace' || e.keyCode === 4) {
         e.preventDefault();
         router.history.back();
       }

--- a/src/shared/providers/SpatialNavProvider.tsx
+++ b/src/shared/providers/SpatialNavProvider.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { init, setFocus, getCurrentFocusKey, setKeyMap } from '@noriginmedia/norigin-spatial-navigation';
-import { useUIStore } from '@lib/store';
+import { useUIStore, usePlayerStore } from '@lib/store';
 
 // Check URL param for debug mode (e.g. ?debug=spatial)
 const isSpatialDebug = typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('debug') === 'spatial';
@@ -90,13 +90,15 @@ export function SpatialNavProvider({ children }: SpatialNavProviderProps) {
         (document.activeElement as HTMLElement)?.blur();
       }
 
-      // Back button handler (TV remotes: Escape, Tizen: 10009, LG: 461)
-      if (e.key === 'Escape' || e.keyCode === 10009 || e.keyCode === 461) {
+      // Back button handler (TV remotes: Escape, Fire TV: 4, Tizen: 10009, LG: 461)
+      if (e.key === 'Escape' || e.keyCode === 4 || e.keyCode === 10009 || e.keyCode === 461) {
+        // Skip if player is active — usePlayerKeyboard handles back during playback
+        if (usePlayerStore.getState().currentStreamId) return;
         // Back navigation — let the app's router handle it
-        // norigin doesn't handle back, so we rely on browser/app history
         if (e.key !== 'Escape') {
           window.history.back();
           e.preventDefault();
+          e.stopPropagation(); // Prevent useBackNavigation from double-navigating
         }
       }
 


### PR DESCRIPTION
## Summary
- Add Fire TV `keyCode 4` handling to player keyboard hook, SpatialNavProvider, and useBackNavigation
- Skip `document.fullscreenElement` check in TV mode — player uses CSS fullscreen, not browser API
- Add player-active guard in SpatialNavProvider to prevent `history.back()` during playback
- Add `stopPropagation()` in SpatialNavProvider to prevent double-navigation from useBackNavigation

## Test plan
- [ ] Fire Stick: play video → press back → player closes, returns to previous screen
- [ ] Fire Stick: on any page (no player) → press back → navigates to previous page
- [ ] Desktop: Escape during playback → player closes
- [ ] Desktop: Escape on a page → navigates back

🤖 Generated with [Claude Code](https://claude.com/claude-code)