### PR TITLE
fix: add prominent focus visual feedback to VOD controls

### DIFF
--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -61,8 +61,8 @@ function FocusableSearchInput({ value, onChange, seriesId }: {
     <div
       ref={ref}
       {...focusProps}
-      className={`relative flex-1 min-w-[180px] max-w-xs rounded-lg ${
-        showFocusRing ? 'ring-2 ring-teal ring-offset-1 ring-offset-obsidian' : ''
+      className={`relative flex-1 min-w-[180px] max-w-xs rounded-lg transition-[box-shadow,transform,filter] ${
+        showFocusRing ? 'ring-2 ring-teal ring-offset-1 ring-offset-obsidian shadow-[0_0_16px_rgba(45,212,191,0.25)] scale-105' : ''
       }`}
     >
       <svg

--- a/src/features/vod/components/MovieDetail.tsx
+++ b/src/features/vod/components/MovieDetail.tsx
@@ -24,7 +24,7 @@ function StartOverButton({ vodId, onStartOver }: { vodId: string; onStartOver: (
       variant="secondary"
       size="lg"
       onClick={onStartOver}
-      className={showFocusRing ? 'ring-2 ring-offset-2 ring-offset-obsidian ring-teal' : ''}
+      className={showFocusRing ? 'ring-2 ring-offset-2 ring-offset-obsidian ring-teal scale-105 bg-surface-hover shadow-[0_0_16px_rgba(45,212,191,0.2)] border-teal/40' : ''}
       data-focus-key={`vod-restart-${vodId}`}
     >
       <svg className="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -190,7 +190,7 @@ export function MovieDetail() {
                   {...playFocusProps}
                   size="lg"
                   onClick={() => { setPlayerStartTime(savedProgress); setIsPlayerOpen(true); }}
-                  className={playFocusRing ? 'ring-2 ring-offset-2 ring-offset-obsidian ring-teal' : ''}
+                  className={playFocusRing ? 'ring-2 ring-offset-2 ring-offset-obsidian ring-teal scale-105 shadow-[0_0_20px_rgba(45,212,191,0.35)] brightness-110' : ''}
                   data-focus-key={`vod-play-${vodId}`}
                 >
                   <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">

--- a/src/features/vod/components/SortFilterBar.tsx
+++ b/src/features/vod/components/SortFilterBar.tsx
@@ -28,7 +28,7 @@ function FocusableChip({ id, label, isActive, onSelect, activeClass, inactiveCla
       ref={ref}
       {...focusProps}
       onClick={onSelect}
-      className={isActive ? activeClass : showFocusRing ? `${inactiveClass} ring-2 ring-teal/50` : inactiveClass}
+      className={isActive ? activeClass : showFocusRing ? `${inactiveClass} ring-2 ring-teal/50 scale-110 shadow-[0_0_12px_rgba(45,212,191,0.2)] text-teal` : inactiveClass}
     >
       {label}
     </button>
@@ -64,8 +64,8 @@ export function SortFilterBar({ sort, onSortChange, filters, onFiltersChange, ge
             label={`${r === null ? 'Any' : `${r}+`} ★`}
             isActive={filters.minRating === r}
             onSelect={() => onFiltersChange({ ...filters, minRating: r })}
-            activeClass="px-2.5 py-1 rounded-md text-xs font-medium transition-[background-color,border-color,color] bg-warning/15 text-warning border border-warning/30"
-            inactiveClass="px-2.5 py-1 rounded-md text-xs font-medium transition-[background-color,border-color,color] bg-surface-raised text-text-muted border border-border hover:text-text-secondary"
+            activeClass="px-2.5 py-1 rounded-md text-xs font-medium transition-[background-color,border-color,color,transform,box-shadow] bg-warning/15 text-warning border border-warning/30"
+            inactiveClass="px-2.5 py-1 rounded-md text-xs font-medium transition-[background-color,border-color,color,transform,box-shadow] bg-surface-raised text-text-muted border border-border hover:text-text-secondary"
           />
         ))}
       </div>
@@ -78,8 +78,8 @@ export function SortFilterBar({ sort, onSortChange, filters, onFiltersChange, ge
             label="All Genres"
             isActive={!filters.genre}
             onSelect={() => onFiltersChange({ ...filters, genre: null })}
-            activeClass="px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-[background-color,border-color,color] bg-teal/15 text-teal border border-teal/30"
-            inactiveClass="px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-[background-color,border-color,color] bg-surface-raised text-text-muted border border-border hover:text-text-secondary"
+            activeClass="px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-[background-color,border-color,color,transform,box-shadow] bg-teal/15 text-teal border border-teal/30"
+            inactiveClass="px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-[background-color,border-color,color,transform,box-shadow] bg-surface-raised text-text-muted border border-border hover:text-text-secondary"
           />
           {genres.slice(0, 15).map((g) => (
             <FocusableChip
@@ -88,8 +88,8 @@ export function SortFilterBar({ sort, onSortChange, filters, onFiltersChange, ge
               label={g}
               isActive={filters.genre === g}
               onSelect={() => onFiltersChange({ ...filters, genre: filters.genre === g ? null : g })}
-              activeClass="px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-[background-color,border-color,color] bg-teal/15 text-teal border border-teal/30"
-              inactiveClass="px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-[background-color,border-color,color] bg-surface-raised text-text-muted border border-border hover:text-text-secondary"
+              activeClass="px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-[background-color,border-color,color,transform,box-shadow] bg-teal/15 text-teal border border-teal/30"
+              inactiveClass="px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-[background-color,border-color,color,transform,box-shadow] bg-surface-raised text-text-muted border border-border hover:text-text-secondary"
             />
           ))}
         </div>

--- a/src/features/vod/components/VODPage.tsx
+++ b/src/features/vod/components/VODPage.tsx
@@ -32,8 +32,8 @@ function FocusableSearchInput({ searchQuery, setSearchQuery }: {
         placeholder="Search movies..."
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
-        className={`w-full max-w-xs px-4 py-2 bg-surface-raised border rounded-lg text-text-primary placeholder:text-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-teal/50 focus:border-teal-dim transition-[border-color,box-shadow] ${
-          showFocusRing ? 'border-teal ring-2 ring-teal/50' : 'border-border'
+        className={`w-full max-w-xs px-4 py-2 bg-surface-raised border rounded-lg text-text-primary placeholder:text-text-muted text-sm focus:outline-none focus:ring-2 focus:ring-teal/50 focus:border-teal-dim transition-[border-color,box-shadow,transform,filter] ${
+          showFocusRing ? 'border-teal ring-2 ring-teal/50 shadow-[0_0_16px_rgba(45,212,191,0.25)] scale-105' : 'border-border'
         }`}
       />
     </div>

--- a/src/shared/components/Button.tsx
+++ b/src/shared/components/Button.tsx
@@ -26,7 +26,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={disabled}
-        className={`inline-flex items-center justify-center font-medium rounded-lg transition-[background-color,box-shadow,opacity] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-obsidian disabled:opacity-50 disabled:cursor-not-allowed ${variants[variant]} ${sizes[size]} ${className}`}
+        className={`inline-flex items-center justify-center font-medium rounded-lg transition-[background-color,box-shadow,opacity,transform,filter] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-obsidian disabled:opacity-50 disabled:cursor-not-allowed ${variants[variant]} ${sizes[size]} ${className}`}
         {...props}
       >
         {children}


### PR DESCRIPTION
## Summary
- VOD action buttons (Play/Resume, Start Over), search inputs, and sort/filter chips had nearly invisible focus states on TV (thin ring only)
- Added scale-up (105-110%), teal glow shadow, and brightness boost on D-pad focus — matching ContentCard focus treatment
- Added `transform` and `filter` to Button base transition for smooth animation
- 5 files, CSS-only changes, no logic changes

## Test plan
- [ ] Navigate VOD page with arrow keys — verify search input glows + scales on focus
- [ ] Navigate to movie detail — verify Play/Resume and Start Over buttons glow + scale on focus
- [ ] Navigate filter chips (rating, genre) — verify scale + glow on focus
- [ ] Open series detail — verify episode search input glows + scales on focus
- [ ] Mouse hover should NOT show focus ring (only D-pad/keyboard)

Generated with Claude Code