### PR TITLE
fix: back button guard for inline PlayerPage

### DIFF
--- a/src/shared/hooks/useBackNavigation.ts
+++ b/src/shared/hooks/useBackNavigation.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useRouter } from '@tanstack/react-router';
-import { usePlayerStore } from '@lib/store';
+import { usePlayerStore, useUIStore } from '@lib/store';
 
 /**
  * Handles Escape and Backspace as "Back" navigation.
@@ -22,7 +22,8 @@ export function useBackNavigation() {
       ) return;
 
       // Don't intercept when player is active — usePlayerKeyboard handles it
-      if (usePlayerStore.getState().currentStreamId) return;
+      // Check both global store (FullscreenPlayer) and suppressArrowNav (inline PlayerPage)
+      if (usePlayerStore.getState().currentStreamId || useUIStore.getState().suppressArrowNav) return;
 
       if (e.key === 'Escape' || e.key === 'Backspace' || e.keyCode === 4) {
         e.preventDefault();

--- a/src/shared/providers/SpatialNavProvider.tsx
+++ b/src/shared/providers/SpatialNavProvider.tsx
@@ -93,7 +93,8 @@ export function SpatialNavProvider({ children }: SpatialNavProviderProps) {
       // Back button handler (TV remotes: Escape, Fire TV: 4, Tizen: 10009, LG: 461)
       if (e.key === 'Escape' || e.keyCode === 4 || e.keyCode === 10009 || e.keyCode === 461) {
         // Skip if player is active — usePlayerKeyboard handles back during playback
-        if (usePlayerStore.getState().currentStreamId) return;
+        // Check both global store (FullscreenPlayer) and suppressArrowNav (inline PlayerPage)
+        if (usePlayerStore.getState().currentStreamId || useUIStore.getState().suppressArrowNav) return;
         // Back navigation — let the app's router handle it
         if (e.key !== 'Escape') {
           window.history.back();


### PR DESCRIPTION
## Summary
- SpatialNavProvider and useBackNavigation only checked `currentStreamId` (global store) for player-active guard
- Inline PlayerPage (SeriesDetail, MovieDetail) doesn't set `currentStreamId` — back presses fired `window.history.back()` instead of closing player
- Fix: also check `suppressArrowNav` flag, which PlayerPage sets in TV mode

## Test plan
- [ ] Play a series episode on TV — back button closes player (not navigate away)
- [ ] Play a movie on TV — back button still closes player
- [ ] On series detail page (no player) — back button navigates to series list
- [ ] Desktop Escape key still works for both player close and navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)