### PR TITLE
fix: use history.back() instead of hardcoded routes for back navigation

### DIFF
--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
-import { useParams, useNavigate } from '@tanstack/react-router';
+import { useParams, useRouter } from '@tanstack/react-router';
 import { useSeriesInfo } from '../api';
 import { useWatchHistory } from '@features/history/api';
 import { StarRating } from '@shared/components/StarRating';
@@ -342,7 +342,8 @@ function FocusableEpisodeItem({
 
 export function SeriesDetail() {
   const { seriesId } = useParams({ from: '/_authenticated/series/$seriesId' });
-  const navigate = useNavigate();
+  const router = useRouter();
+  const goBack = () => router.history.back();
   const { data, isLoading } = useSeriesInfo(seriesId);
   const { data: watchHistory } = useWatchHistory();
 
@@ -531,7 +532,7 @@ export function SeriesDetail() {
 
   const { ref: backRef, showFocusRing: backFocusRing, focusProps: backFocusProps } = useSpatialFocusable({
     focusKey: `series-back-${seriesId}`,
-    onEnterPress: () => navigate({ to: '/series' }),
+    onEnterPress: goBack,
   });
 
   // Auto-focus: try specific targets using doesFocusableExist to avoid silently setting
@@ -582,8 +583,8 @@ export function SeriesDetail() {
     return (
       <div className="text-center py-12">
         <p className="text-text-muted">Content unavailable. The provider may be temporarily down.</p>
-        <button onClick={() => navigate({ to: '/series' })} className="mt-4 px-4 py-2 bg-teal/15 text-teal rounded-lg text-sm hover:bg-teal/25 transition-colors">
-          Back to Series
+        <button onClick={goBack} className="mt-4 px-4 py-2 bg-teal/15 text-teal rounded-lg text-sm hover:bg-teal/25 transition-colors">
+          Go Back
         </button>
       </div>
     );
@@ -616,7 +617,7 @@ export function SeriesDetail() {
               <button
                 ref={backRef}
                 {...backFocusProps}
-                onClick={() => navigate({ to: '/series' })}
+                onClick={goBack}
                 className={`flex items-center gap-1.5 text-text-secondary hover:text-text-primary text-sm transition-colors min-h-[44px] rounded-lg px-2 py-1 ${
                   backFocusRing ? 'ring-2 ring-teal bg-surface-raised' : ''
                 }`}

--- a/src/features/vod/components/MovieDetail.tsx
+++ b/src/features/vod/components/MovieDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect } from 'react';
-import { useNavigate, useParams } from '@tanstack/react-router';
+import { useParams, useRouter } from '@tanstack/react-router';
 import { useVODInfo } from '../api';
 import { useWatchHistory } from '@features/history/api';
 import { StarRating } from '@shared/components/StarRating';
@@ -37,7 +37,8 @@ function StartOverButton({ vodId, onStartOver }: { vodId: string; onStartOver: (
 
 export function MovieDetail() {
   const { vodId } = useParams({ from: '/_authenticated/vod/$vodId' });
-  const navigate = useNavigate();
+  const router = useRouter();
+  const goBack = () => router.history.back();
   const { data, isLoading } = useVODInfo(vodId);
   const { data: watchHistory } = useWatchHistory();
   const [isPlayerOpen, setIsPlayerOpen] = useState(false);
@@ -63,7 +64,7 @@ export function MovieDetail() {
 
   const { ref: backRef, showFocusRing: backFocusRing, focusProps: backFocusProps } = useSpatialFocusable({
     focusKey: `vod-back-${vodId}`,
-    onEnterPress: () => navigate({ to: '/vod' }),
+    onEnterPress: goBack,
   });
 
   const { ref: closeRef, showFocusRing: closeFocusRing, focusProps: closeFocusProps } = useSpatialFocusable({
@@ -101,8 +102,8 @@ export function MovieDetail() {
     return (
       <div className="text-center py-12">
         <p className="text-text-muted">Content unavailable. The provider may be temporarily down.</p>
-        <button onClick={() => navigate({ to: '/vod' })} className="mt-4 px-4 py-2 bg-teal/15 text-teal rounded-lg text-sm hover:bg-teal/25 transition-colors">
-          Back to Movies
+        <button onClick={goBack} className="mt-4 px-4 py-2 bg-teal/15 text-teal rounded-lg text-sm hover:bg-teal/25 transition-colors">
+          Go Back
         </button>
       </div>
     );
@@ -117,7 +118,7 @@ export function MovieDetail() {
           <button
             ref={backRef}
             {...backFocusProps}
-            onClick={() => navigate({ to: '/vod' })}
+            onClick={goBack}
             className={`flex items-center gap-1 text-text-secondary hover:text-text-primary text-sm mb-4 transition-colors rounded-lg px-2 py-1 ${
               backFocusRing ? 'ring-2 ring-teal bg-surface-raised' : ''
             }`}


### PR DESCRIPTION
## Summary
- **MovieDetail** back button hardcoded `navigate({ to: '/vod' })` — pressing back from any movie always went to the VOD list, even if you came from Language Hub, Home, or Search
- **SeriesDetail** had the same issue with hardcoded `navigate({ to: '/series' })`
- Both now use `router.history.back()` to return to the actual previous page

## Changes
- `MovieDetail.tsx`: replaced `useNavigate` with `useRouter`, 4 hardcoded `/vod` navigations → `goBack()`
- `SeriesDetail.tsx`: same pattern, 3 hardcoded `/series` navigations → `goBack()`

## Test plan
- [ ] Navigate to a movie from Language Hub → press back → should return to Language Hub (not VOD page)
- [ ] Navigate to a movie from Home → press back → should return to Home
- [ ] Navigate to a series from Language Hub → press back → should return to Language Hub
- [ ] Fire Stick: TV remote back button returns to correct page
- [ ] Direct URL access to `/vod/{id}` → back button is safe (no-op, no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)