### PR TITLE
fix: Button test ref type

### DIFF
--- a/src/design-system/primitives/__tests__/Button.test.tsx
+++ b/src/design-system/primitives/__tests__/Button.test.tsx
@@ -88,7 +88,7 @@ describe('Button — default type', () => {
 
 describe('Button — ref forwarding', () => {
   it('forwards ref to the underlying DOM element', () => {
-    const ref = createRef<HTMLElement>();
+    const ref = createRef<HTMLButtonElement>();
     render(<Button ref={ref}>Ref test</Button>);
     expect(ref.current).not.toBeNull();
     expect(ref.current?.tagName).toBe('BUTTON');


### PR DESCRIPTION
1-line fix: HTMLElement → HTMLButtonElement in Button test ref forwarding.