### PR TITLE
fix(sv2-sprint3a): close 3 post-sprint evaluation gaps

### DIFF
--- a/src/features/series/components/SeasonNav.tsx
+++ b/src/features/series/components/SeasonNav.tsx
@@ -1,17 +1,19 @@
 import { memo } from 'react';
+import { useSpatialFocusable } from '@shared/hooks/useSpatialNav';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 export interface SeasonData {
-  air_date: string;
-  episode_count: number;
-  id: number;
-  name: string;
-  overview: string;
   season_number: number;
-  cover: string;
+  name: string;
+  episode_count: number;
+  // Optional fields from full Xtream API response
+  air_date?: string;
+  id?: number;
+  overview?: string;
+  cover?: string;
 }
 
 export interface SeasonNavProps {
@@ -19,6 +21,45 @@ export interface SeasonNavProps {
   activeSeason: number;
   seriesId: string;
   onSeasonChange: (seasonNumber: number) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-component
+// ---------------------------------------------------------------------------
+
+function FocusableSeasonTabInner({
+  season,
+  isActive,
+  onSeasonChange,
+}: {
+  season: SeasonData;
+  isActive: boolean;
+  onSeasonChange: (n: number) => void;
+}) {
+  const { ref, showFocusRing, focusProps } = useSpatialFocusable({
+    focusKey: `series-season-${season.season_number}`,
+    onEnterPress: () => onSeasonChange(season.season_number),
+  });
+
+  return (
+    <button
+      ref={ref}
+      {...focusProps}
+      role="tab"
+      aria-selected={isActive}
+      onClick={() => onSeasonChange(season.season_number)}
+      className={[
+        'px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap min-h-[44px]',
+        'transition-[background-color,border-color,color]',
+        isActive
+          ? 'bg-teal/15 text-teal border border-teal/30'
+          : 'bg-surface-raised text-text-secondary border border-border hover:text-text-primary hover:border-teal/20',
+        showFocusRing ? 'ring-2 ring-teal ring-offset-1 ring-offset-obsidian' : '',
+      ].join(' ')}
+    >
+      {season.name} ({season.episode_count})
+    </button>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -32,26 +73,14 @@ export const SeasonNav = memo(function SeasonNav({
 }: SeasonNavProps) {
   return (
     <div role="tablist" aria-label="Seasons" className="flex gap-2 flex-wrap mb-4">
-      {seasons.map((season) => {
-        const isActive = season.season_number === activeSeason;
-        return (
-          <button
-            key={season.season_number}
-            role="tab"
-            aria-selected={isActive}
-            onClick={() => onSeasonChange(season.season_number)}
-            className={[
-              'px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap min-h-[44px]',
-              'transition-[background-color,border-color,color]',
-              isActive
-                ? 'bg-teal/15 text-teal border border-teal/30'
-                : 'bg-surface-raised text-text-secondary border border-border hover:text-text-primary hover:border-teal/20',
-            ].join(' ')}
-          >
-            {season.name} ({season.episode_count})
-          </button>
-        );
-      })}
+      {seasons.map((season) => (
+        <FocusableSeasonTabInner
+          key={season.season_number}
+          season={season}
+          isActive={season.season_number === activeSeason}
+          onSeasonChange={onSeasonChange}
+        />
+      ))}
     </div>
   );
 });

--- a/src/features/series/components/SeriesDetail.tsx
+++ b/src/features/series/components/SeriesDetail.tsx
@@ -2,18 +2,69 @@ import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
 import { useParams, useRouter } from '@tanstack/react-router';
 import { useSeriesInfo } from '../api';
 import { useWatchHistory } from '@features/history/api';
+import { useIsFavorite, useAddFavorite, useRemoveFavorite } from '@features/favorites/api';
 import { Skeleton } from '@shared/components/Skeleton';
 import { PageTransition } from '@shared/components/PageTransition';
 import { usePlayerStore } from '@lib/store';
 import type { EpisodeEntry } from '@lib/store';
 import { useSpatialFocusable, useSpatialContainer, FocusContext, setFocus, doesFocusableExist } from '@shared/hooks/useSpatialNav';
+import { useFocusStyles } from '@/design-system/focus/useFocusStyles';
 import { SeriesDetailHero } from './SeriesDetailHero';
 import { EpisodeControls } from './EpisodeControls';
 import { FocusableEpisodeItem } from './EpisodeItem';
 import type { Episode } from './EpisodeItem';
-import { FocusableSeasonTab, ResumeButton, LoadMoreButton } from './SeriesDetailSubComponents';
+import { ResumeButton, LoadMoreButton } from './SeriesDetailSubComponents';
+import { SeasonNav } from './SeasonNav';
 
 type EpisodeSortKey = 'latest' | 'oldest' | 'episode';
+
+// ── Favorite Button ────────────────────────────────────────────────────────────
+
+function SeriesFavoriteButton({ seriesId, seriesName, seriesIcon }: { seriesId: string; seriesName: string; seriesIcon?: string }) {
+  const { buttonFocus } = useFocusStyles();
+  const isFavorite = useIsFavorite(seriesId);
+  const { mutate: addFavorite } = useAddFavorite();
+  const { mutate: removeFavorite } = useRemoveFavorite();
+
+  const { ref, showFocusRing, focusProps } = useSpatialFocusable({
+    focusKey: `series-favorite-${seriesId}`,
+    onEnterPress: () => handleToggle(),
+  });
+
+  function handleToggle() {
+    if (isFavorite) {
+      removeFavorite(seriesId);
+    } else {
+      addFavorite({ contentId: seriesId, content_type: 'series', content_name: seriesName, content_icon: seriesIcon });
+    }
+  }
+
+  return (
+    <button
+      ref={ref}
+      {...focusProps}
+      onClick={handleToggle}
+      aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+      className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border transition-[background-color,border-color,color] min-h-[44px] ${
+        isFavorite
+          ? 'bg-teal/15 text-teal border-teal/30'
+          : 'bg-surface-raised text-text-secondary border-border hover:text-text-primary hover:border-teal/20'
+      } ${showFocusRing ? `ring-2 ring-teal ring-offset-1 ring-offset-obsidian ${buttonFocus}` : ''}`}
+      data-focus-key={`series-favorite-${seriesId}`}
+    >
+      {isFavorite ? (
+        <svg className="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+        </svg>
+      ) : (
+        <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+        </svg>
+      )}
+      {isFavorite ? 'Favorited' : 'Favorite'}
+    </button>
+  );
+}
 
 export const EPISODES_PER_PAGE = 50;
 
@@ -159,6 +210,13 @@ export function SeriesDetail() {
                 </button>
               </div>
               <SeriesDetailHero info={info} seasonsCount={seasons.length} channelName={null} />
+              <div className="flex items-center gap-3 mb-4">
+                <SeriesFavoriteButton
+                  seriesId={seriesId}
+                  seriesName={info.name}
+                  seriesIcon={info.cover}
+                />
+              </div>
               {lastWatchedEpisode && (
                 <ResumeButton
                   seriesId={seriesId}
@@ -185,19 +243,13 @@ export function SeriesDetail() {
 
           <FocusContext.Provider value={controlsFocusKey}>
             <div ref={controlsRef}>
-              <div className="mb-4">
-                <div className="flex gap-2 overflow-x-auto scrollbar-hide pb-2" role="tablist">
-                  {computedSeasons.map((season) => (
-                    <FocusableSeasonTab
-                      key={season.season_number}
-                      seasonNumber={season.season_number}
-                      name={season.name}
-                      episodeCount={season.episode_count}
-                      isActive={activeSeason === season.season_number}
-                      onSelect={() => { setActiveSeason(season.season_number); setEpisodeSearch(''); }}
-                    />
-                  ))}
-                </div>
+              <div className="mb-4 overflow-x-auto scrollbar-hide pb-2">
+                <SeasonNav
+                  seasons={computedSeasons}
+                  activeSeason={activeSeason ?? 0}
+                  seriesId={seriesId}
+                  onSeasonChange={(n) => { setActiveSeason(n); setEpisodeSearch(''); }}
+                />
               </div>
               <EpisodeControls
                 seriesId={seriesId}

--- a/src/features/series/components/SeriesDetailSubComponents.tsx
+++ b/src/features/series/components/SeriesDetailSubComponents.tsx
@@ -1,46 +1,14 @@
 /**
  * Sub-components for SeriesDetail:
- * - FocusableSeasonTab
  * - ResumeButton
  * - LoadMoreButton
  *
  * Extracted to keep SeriesDetail.tsx under 300 lines (AC-03).
+ * Season tab rendering moved to SeasonNav component.
  */
 import { useSpatialFocusable } from '@shared/hooks/useSpatialNav';
 import { useFocusStyles } from '@/design-system/focus/useFocusStyles';
 import { formatDuration } from '@shared/utils/formatDuration';
-
-// ── FocusableSeasonTab ────────────────────────────────────────────────────────
-
-export function FocusableSeasonTab({ seasonNumber, name, episodeCount, isActive, onSelect }: {
-  seasonNumber: number;
-  name: string;
-  episodeCount: number;
-  isActive: boolean;
-  onSelect: () => void;
-}) {
-  const { ref, showFocusRing, focusProps } = useSpatialFocusable({
-    focusKey: `series-season-${seasonNumber}`,
-    onEnterPress: onSelect,
-  });
-
-  return (
-    <button
-      ref={ref}
-      {...focusProps}
-      role="tab"
-      aria-selected={isActive}
-      onClick={onSelect}
-      className={`px-5 py-2.5 rounded-lg text-sm font-medium whitespace-nowrap transition-[background-color,border-color,color] min-h-[44px] ${
-        isActive
-          ? 'bg-teal/15 text-teal border border-teal/30'
-          : 'bg-surface-raised text-text-secondary border border-border hover:text-text-primary hover:border-teal/20'
-      } ${showFocusRing ? 'ring-2 ring-teal ring-offset-1 ring-offset-obsidian' : ''}`}
-    >
-      {name} ({episodeCount})
-    </button>
-  );
-}
 
 // ── ResumeButton ──────────────────────────────────────────────────────────────
 

--- a/src/features/vod/components/MovieDetail.tsx
+++ b/src/features/vod/components/MovieDetail.tsx
@@ -2,6 +2,7 @@ import { useMemo, useEffect } from 'react';
 import { useParams, useRouter } from '@tanstack/react-router';
 import { useVODInfo } from '../api';
 import { useWatchHistory } from '@features/history/api';
+import { useIsFavorite, useAddFavorite, useRemoveFavorite } from '@features/favorites/api';
 import { StarRating } from '@shared/components/StarRating';
 import { Badge } from '@shared/components/Badge';
 import { Button } from '@shared/components/Button';
@@ -33,6 +34,50 @@ function StartOverButton({ vodId, onStartOver }: { vodId: string; onStartOver: (
         <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h5M20 20v-5h-5M4 9a8 8 0 0113.09-3.09L20 9M20 15a8 8 0 01-13.09 3.09L4 15" />
       </svg>
       Start Over
+    </Button>
+  );
+}
+
+function FavoriteButton({ vodId, movieName, movieIcon }: { vodId: string; movieName: string; movieIcon?: string }) {
+  const { buttonFocus } = useFocusStyles();
+  const isFavorite = useIsFavorite(vodId);
+  const { mutate: addFavorite } = useAddFavorite();
+  const { mutate: removeFavorite } = useRemoveFavorite();
+
+  const { ref, showFocusRing, focusProps } = useSpatialFocusable({
+    focusKey: `vod-favorite-${vodId}`,
+    onEnterPress: () => handleToggle(),
+  });
+
+  function handleToggle() {
+    if (isFavorite) {
+      removeFavorite(vodId);
+    } else {
+      addFavorite({ contentId: vodId, content_type: 'vod', content_name: movieName, content_icon: movieIcon });
+    }
+  }
+
+  return (
+    <Button
+      ref={ref}
+      {...focusProps}
+      variant="secondary"
+      size="lg"
+      onClick={handleToggle}
+      aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+      className={showFocusRing ? `${buttonFocus} scale-105 bg-surface-hover shadow-[0_0_16px_rgba(45,212,191,0.2)] border-teal/40` : ''}
+      data-focus-key={`vod-favorite-${vodId}`}
+    >
+      {isFavorite ? (
+        <svg className="w-5 h-5 mr-2 text-teal" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+        </svg>
+      ) : (
+        <svg className="w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+        </svg>
+      )}
+      {isFavorite ? 'Favorited' : 'Favorite'}
     </Button>
   );
 }
@@ -158,7 +203,7 @@ export function MovieDetail() {
                   <Badge key={g} variant="teal">{g}</Badge>
                 ))}
               </div>
-              <div className="flex gap-3">
+              <div className="flex gap-3 flex-wrap">
                 <Button
                   ref={playRef}
                   {...playFocusProps}
@@ -178,6 +223,11 @@ export function MovieDetail() {
                     onStartOver={() => playStream(vodId, 'vod', info.name, 0)}
                   />
                 )}
+                <FavoriteButton
+                  vodId={vodId}
+                  movieName={info.name}
+                  movieIcon={info.movie_image}
+                />
               </div>
             </div>
           </div>

--- a/src/features/vod/components/MovieGrid.tsx
+++ b/src/features/vod/components/MovieGrid.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { PosterCard } from '@/design-system/cards/PosterCard';
 import { EmptyState } from '@shared/components/EmptyState';
+import { VirtualGrid } from '@shared/components/VirtualGrid';
 import type { XtreamVODStream } from '@shared/types/api';
 
 // ---------------------------------------------------------------------------
@@ -25,8 +26,11 @@ export const MovieGrid = memo(function MovieGrid({ movies, onFavoriteToggle }: M
   }
 
   return (
-    <div className="grid grid-cols-3 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3">
-      {movies.map((movie) => {
+    <VirtualGrid
+      items={movies}
+      estimateSize={280}
+      overscan={3}
+      renderItem={(movie) => {
         // Extract year from the added timestamp (approximate — no releaseDate on stream list)
         const year = movie.added
           ? new Date(parseInt(movie.added, 10) * 1000).getFullYear()
@@ -34,7 +38,6 @@ export const MovieGrid = memo(function MovieGrid({ movies, onFavoriteToggle }: M
 
         return (
           <PosterCard
-            key={movie.stream_id}
             title={movie.name}
             imageUrl={movie.stream_icon}
             rating={movie.rating_5based > 0 ? movie.rating_5based.toFixed(1) : undefined}
@@ -49,7 +52,7 @@ export const MovieGrid = memo(function MovieGrid({ movies, onFavoriteToggle }: M
             focusKey={`movie-grid-${movie.stream_id}`}
           />
         );
-      })}
-    </div>
+      }}
+    />
   );
 });

--- a/src/features/vod/components/__tests__/MovieGrid.test.tsx
+++ b/src/features/vod/components/__tests__/MovieGrid.test.tsx
@@ -8,6 +8,18 @@ vi.mock('@/shared/utils/isTVMode', () => ({
   isTVMode: false,
 }));
 
+// ── mock VirtualGrid (useVirtualizer requires DOM layout unavailable in jsdom) ─
+
+vi.mock('@shared/components/VirtualGrid', () => ({
+  VirtualGrid: ({ items, renderItem }: any) => (
+    <div data-testid="virtual-grid">
+      {items.map((item: any, index: number) => (
+        <div key={item.stream_id ?? index}>{renderItem(item, index)}</div>
+      ))}
+    </div>
+  ),
+}));
+
 // ── mock PosterCard ────────────────────────────────────────────────────────────
 
 vi.mock('@/design-system/cards/PosterCard', () => ({


### PR DESCRIPTION
## Summary

- **GAP 1 — VirtualGrid wired into VOD pages**: `MovieGrid.tsx` now uses `VirtualGrid` (@tanstack/react-virtual) instead of a plain CSS grid. Row virtualization with responsive column detection handles 100+ item catalogs without layout thrashing. `MovieGrid.test.tsx` mocks `VirtualGrid` (jsdom has no DOM layout for useVirtualizer).

- **GAP 2 — Favorite toggle in MovieDetail + SeriesDetail**: Both detail pages now have a spatially-focusable favorite button using `useIsFavorite`/`useAddFavorite`/`useRemoveFavorite`. Optimistic UI, filled/outline heart icons, correct `aria-label`. Both components stay under 300 lines (MovieDetail 264, SeriesDetail 296).

- **GAP 3 — SeasonNav integrated into SeriesDetail (Option A)**: `SeasonNav` updated with D-pad support (`useSpatialFocusable` per tab) and flexible `SeasonData` type (extra fields optional). `SeriesDetail` now uses `SeasonNav` — the inline `FocusableSeasonTab` loop is gone. `FocusableSeasonTab` removed from `SeriesDetailSubComponents` (lives as private sub-component inside `SeasonNav`). No dead code remains.

## Test plan

- [x] Sprint 3A tests: 67/67 pass (`MovieGrid`, `MovieDetail`, `VODPage`, `SeasonNav`, `EpisodeList`, `SeriesDetail`)
- [x] Full suite: 329/331 pass (2 pre-existing `usePlayerKeyboard` failures, unchanged)
- [x] Build: `npm run build` clean, 7.94s
- [x] All modified files under 300 lines
- [x] No hardcoded secrets or SQL injection vectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)