### PR TITLE
fix: global nav D-pad cross-context navigation (Sprint 10)

### DIFF
--- a/src/routes/__tests__/-_authenticated.lazy.test.tsx
+++ b/src/routes/__tests__/-_authenticated.lazy.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Sprint 10 — Global nav bar D-pad cross-context navigation tests
+ *
+ * Verifies that GlobalNavLink items are wrapped in a proper norigin container
+ * (global-nav) so D-pad can cross between the nav bar and page content.
+ *
+ * The bug: nav links were registered directly under SN:ROOT without a container,
+ * isolating them from page content containers and preventing UP/DOWN nav crossing.
+ * The fix: useSpatialContainer({ focusKey: "global-nav" }) + FocusContext.Provider.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// ── Track container registrations ─────────────────────────────────────────────
+
+const containerCalls: Array<{
+  focusKey?: string;
+  saveLastFocusedChild?: boolean;
+}> = [];
+const focusableCalls: Array<{ focusKey?: string }> = [];
+
+vi.mock("@shared/hooks/useSpatialNav", () => ({
+  useSpatialFocusable: (opts: { focusKey?: string } = {}) => {
+    focusableCalls.push({ focusKey: opts.focusKey });
+    return {
+      ref: { current: null },
+      focused: false,
+      showFocusRing: false,
+      focusProps: { onMouseEnter: vi.fn(), "data-focus-key": opts.focusKey },
+    };
+  },
+  useSpatialContainer: (
+    opts: { focusKey?: string; saveLastFocusedChild?: boolean } = {},
+  ) => {
+    containerCalls.push(opts);
+    return {
+      ref: { current: null },
+      focusKey: opts.focusKey ?? "test-container",
+    };
+  },
+  FocusContext: {
+    Provider: ({
+      children,
+      value,
+    }: {
+      children: React.ReactNode;
+      value: string;
+    }) => <div data-testid={`focus-ctx-${value}`}>{children}</div>,
+  },
+  setFocus: vi.fn(),
+}));
+
+vi.mock("@shared/components/TopNav", () => ({
+  TopNav: () => <nav aria-label="Top nav" />,
+}));
+
+vi.mock("@features/auth/hooks/useAuth", () => ({
+  useAuthCheck: vi.fn(),
+}));
+
+vi.mock("@shared/hooks/useBackNavigation", () => ({
+  useBackNavigation: vi.fn(),
+}));
+
+vi.mock("@features/auth/hooks/useTokenRefresh", () => ({
+  useTokenRefresh: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  createLazyFileRoute: () => (cfg: { component: React.ComponentType }) => cfg,
+  Outlet: () => <div data-testid="outlet" />,
+  Link: ({
+    children,
+    to,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    to: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+  useParams: () => ({}),
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+// We need to import the component function directly since the route export
+// is wrapped. Import the module and render the component.
+import type * as AuthModule from "../_authenticated.lazy";
+
+let AuthenticatedLayout: React.ComponentType;
+
+beforeEach(async () => {
+  containerCalls.length = 0;
+  focusableCalls.length = 0;
+  vi.resetModules();
+
+  // Dynamic import after mocks are set up
+  const mod = await import("../_authenticated.lazy");
+  // The route config has the component; since createLazyFileRoute is mocked
+  // to return the config object, Route.component is the AuthenticatedLayout.
+  // But createLazyFileRoute mock returns (cfg) => cfg, so Route = { component: AuthenticatedLayout }
+  AuthenticatedLayout = (
+    mod.Route as unknown as { component: React.ComponentType }
+  ).component;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AuthenticatedLayout — global nav FocusContext container", () => {
+  it("registers a global-nav spatial container", async () => {
+    render(<AuthenticatedLayout />);
+    const globalNavContainer = containerCalls.find(
+      (c) => c.focusKey === "global-nav",
+    );
+    expect(globalNavContainer).toBeDefined();
+  });
+
+  it("global-nav container has saveLastFocusedChild: true for D-pad memory", async () => {
+    render(<AuthenticatedLayout />);
+    const globalNavContainer = containerCalls.find(
+      (c) => c.focusKey === "global-nav",
+    );
+    expect(globalNavContainer?.saveLastFocusedChild).toBe(true);
+  });
+
+  it("wraps nav links in FocusContext.Provider with global-nav focus key", async () => {
+    render(<AuthenticatedLayout />);
+    // The FocusContext.Provider mock renders as a div with data-testid="focus-ctx-<value>"
+    const ctxProvider = screen.getByTestId("focus-ctx-global-nav");
+    expect(ctxProvider).toBeInTheDocument();
+  });
+
+  it("renders all 5 global nav links inside the focus context provider", async () => {
+    render(<AuthenticatedLayout />);
+    const ctxProvider = screen.getByTestId("focus-ctx-global-nav");
+    const navLinks = ctxProvider.querySelectorAll("a");
+    expect(navLinks.length).toBe(5);
+  });
+
+  it("registers global-nav-telugu, global-nav-hindi, global-nav-english, global-nav-sports, global-nav-search as focusables", async () => {
+    render(<AuthenticatedLayout />);
+    const expectedKeys = [
+      "global-nav-telugu",
+      "global-nav-hindi",
+      "global-nav-english",
+      "global-nav-sports",
+      "global-nav-search",
+    ];
+    for (const key of expectedKeys) {
+      expect(focusableCalls.some((c) => c.focusKey === key)).toBe(true);
+    }
+  });
+
+  it("renders Outlet (page content) outside the global-nav FocusContext", async () => {
+    render(<AuthenticatedLayout />);
+    const outlet = screen.getByTestId("outlet");
+    const ctxProvider = screen.getByTestId("focus-ctx-global-nav");
+    // Outlet must NOT be inside the global-nav FocusContext.Provider
+    expect(ctxProvider.contains(outlet)).toBe(false);
+  });
+
+  it("nav links render with correct href values", async () => {
+    render(<AuthenticatedLayout />);
+    const links = screen.getAllByRole("link");
+    const hrefs = links.map((l) => l.getAttribute("href"));
+    expect(hrefs).toContain("/language/telugu");
+    expect(hrefs).toContain("/language/hindi");
+    expect(hrefs).toContain("/language/english");
+    expect(hrefs).toContain("/sports");
+    expect(hrefs).toContain("/search");
+  });
+
+  it("nav links carry data-focus-key attributes for norigin DOM lookup", async () => {
+    render(<AuthenticatedLayout />);
+    const ctxProvider = screen.getByTestId("focus-ctx-global-nav");
+    const links = ctxProvider.querySelectorAll("[data-focus-key]");
+    expect(links.length).toBe(5);
+  });
+});

--- a/src/routes/_authenticated.lazy.tsx
+++ b/src/routes/_authenticated.lazy.tsx
@@ -8,7 +8,11 @@ import { TopNav } from "@shared/components/TopNav";
 import { useAuthCheck } from "@features/auth/hooks/useAuth";
 import { useBackNavigation } from "@shared/hooks/useBackNavigation";
 import { useTokenRefresh } from "@features/auth/hooks/useTokenRefresh";
-import { useSpatialFocusable } from "@shared/hooks/useSpatialNav";
+import {
+  useSpatialFocusable,
+  useSpatialContainer,
+  FocusContext,
+} from "@shared/hooks/useSpatialNav";
 
 export const Route = createLazyFileRoute("/_authenticated")({
   component: AuthenticatedLayout,
@@ -70,6 +74,14 @@ function AuthenticatedLayout() {
   const currentPath =
     typeof window !== "undefined" ? window.location.pathname : "";
 
+  // Container for global nav bar — gives norigin a proper parent so D-pad
+  // can cross between nav and page content (fixes FocusContext isolation).
+  const { ref: globalNavRef, focusKey: globalNavFocusKey } =
+    useSpatialContainer({
+      focusKey: "global-nav",
+      saveLastFocusedChild: true,
+    });
+
   return (
     <div className="min-h-screen bg-obsidian">
       <TopNav />
@@ -78,26 +90,30 @@ function AuthenticatedLayout() {
         tabIndex={-1}
         className="min-h-screen pt-14 px-6 lg:px-10 overflow-y-auto scrollbar-hide focus:outline-none"
       >
-        {/* Global navigation — always visible */}
-        <div className="pt-2 pb-2">
-          <div className="flex items-center gap-2">
-            {GLOBAL_NAV.map((item) => (
-              <GlobalNavLink
-                key={item.key}
-                to={item.to}
-                navKey={item.key}
-                label={item.label}
-                isActive={
-                  item.key === "sports"
-                    ? currentPath === "/sports"
-                    : item.key === "search"
-                      ? currentPath === "/search"
-                      : params.lang === item.key
-                }
-              />
-            ))}
+        {/* Global navigation — always visible.
+            FocusContext.Provider anchors the nav links under the global-nav
+            container so norigin can traverse up/down between nav and page content. */}
+        <FocusContext.Provider value={globalNavFocusKey}>
+          <div ref={globalNavRef} className="pt-2 pb-2">
+            <div className="flex items-center gap-2">
+              {GLOBAL_NAV.map((item) => (
+                <GlobalNavLink
+                  key={item.key}
+                  to={item.to}
+                  navKey={item.key}
+                  label={item.label}
+                  isActive={
+                    item.key === "sports"
+                      ? currentPath === "/sports"
+                      : item.key === "search"
+                        ? currentPath === "/search"
+                        : params.lang === item.key
+                  }
+                />
+              ))}
+            </div>
           </div>
-        </div>
+        </FocusContext.Provider>
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
## Summary

- **Bug**: `GlobalNavLink` items (Telugu/Hindi/English/Sports/Search) were registered directly under `SN:ROOT` in norigin's focus tree — no parent container. Page content uses `FocusContext.Provider` containers (e.g., `LANGUAGE_HUB_PAGE`). This FocusContext isolation prevented D-pad from crossing between the nav bar and page content.
- **Fix**: Added `useSpatialContainer({ focusKey: "global-nav", saveLastFocusedChild: true })` in `AuthenticatedLayout` and wrapped the nav links in `FocusContext.Provider`. Nav links now form a proper container in norigin's tree, enabling UP/DOWN traversal between nav and page content.
- **Scope**: Single file change in `_authenticated.lazy.tsx` + 8 unit tests. No other spatial nav settings touched (per CLAUDE.md rule: incremental fixes only).

## What changed

`src/routes/_authenticated.lazy.tsx` — added `useSpatialContainer` + `FocusContext.Provider` around the global nav links row.

**Before:**
```
SN:ROOT
├── top-nav → profile-btn
├── global-nav-telugu  ← floating at root, no container
├── global-nav-hindi
└── LANGUAGE_HUB_PAGE → langhub-tab-movies, ...
```

**After:**
```
SN:ROOT
├── top-nav → profile-btn
├── global-nav (container, saveLastFocusedChild)  ← new
│   ├── global-nav-telugu
│   ├── global-nav-hindi, ...
└── LANGUAGE_HUB_PAGE → langhub-tab-movies, ...
```

## Test plan

- [x] 8 new unit tests in `src/routes/__tests__/-_authenticated.lazy.test.tsx`
  - Container registers with `focusKey: "global-nav"`
  - Container has `saveLastFocusedChild: true`
  - `FocusContext.Provider` wraps all 5 nav links
  - Outlet (page content) is outside the nav context
  - All 5 focus keys registered as focusables
  - Nav links carry `data-focus-key` attributes
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [ ] Manual: verify D-pad UP from page content lands on a global nav link (Fire Stick / TV mode)

Closes [SRI-7](/SRI/issues/SRI-7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)