### PR TITLE
[SRI-33] Design system primitives: Input, Toggle, TV-focus for Button & Badge

### DIFF
--- a/src/design-system/primitives/Badge.tsx
+++ b/src/design-system/primitives/Badge.tsx
@@ -1,33 +1,61 @@
-import { cn } from '@/shared/utils/cn';
+import { cn } from "@/shared/utils/cn";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export type BadgeVariant = 'default' | 'new' | 'live' | 'rating';
-export type BadgeSize = 'sm' | 'md';
+/**
+ * Badge variants using new design-system tokens only.
+ * - primary   : teal accent — highlights / new content
+ * - secondary : surface-raised — neutral label
+ * - status    : maps to semantic sub-variants via `statusColor` prop
+ * - new       : alias kept for back-compat with content-rail badges
+ * - live      : live-stream indicator with pulsing dot
+ * - rating    : star + score
+ */
+export type BadgeVariant =
+  | "primary"
+  | "secondary"
+  | "status"
+  | "new"
+  | "live"
+  | "rating";
+export type BadgeSize = "sm" | "md" | "lg";
+export type BadgeStatusColor = "success" | "warning" | "error" | "info";
 
 export interface BadgeProps {
   variant?: BadgeVariant;
   size?: BadgeSize;
+  /** Only applies when variant="status" — maps to semantic color token */
+  statusColor?: BadgeStatusColor;
   className?: string;
   children?: React.ReactNode;
 }
 
 // ---------------------------------------------------------------------------
-// Style maps
+// Style maps (new design-system tokens only — zero old CSS)
 // ---------------------------------------------------------------------------
 
 const variantClasses: Record<BadgeVariant, string> = {
-  default: 'bg-bg-tertiary text-text-secondary',
-  new: 'bg-accent-teal/20 text-accent-teal',
-  live: 'bg-error/20 text-error',
-  rating: 'bg-warning/20 text-warning',
+  primary: "bg-accent-teal/20 text-accent-teal",
+  secondary: "bg-bg-tertiary text-text-secondary border border-border",
+  status: "bg-bg-tertiary text-text-secondary", // overridden per statusColor
+  new: "bg-accent-teal/20 text-accent-teal",
+  live: "bg-error/20 text-error",
+  rating: "bg-warning/20 text-warning",
+};
+
+const statusColorClasses: Record<BadgeStatusColor, string> = {
+  success: "bg-success/15 text-success",
+  warning: "bg-warning/15 text-warning",
+  error: "bg-error/15 text-error",
+  info: "bg-info/15 text-info",
 };
 
 const sizeClasses: Record<BadgeSize, string> = {
-  sm: 'text-xs px-1.5 py-0.5',
-  md: 'text-sm px-2 py-0.5',
+  sm: "text-xs px-1.5 py-0.5",
+  md: "text-sm px-2 py-0.5",
+  lg: "text-base px-3 py-1",
 };
 
 // ---------------------------------------------------------------------------
@@ -40,7 +68,7 @@ function LiveDot() {
     <span
       aria-hidden="true"
       className="inline-block w-1.5 h-1.5 rounded-full bg-error"
-      style={{ animation: 'pulse 2s infinite' }}
+      style={{ animation: "pulse 2s infinite" }}
     />
   );
 }
@@ -64,24 +92,30 @@ function StarIcon() {
 // ---------------------------------------------------------------------------
 
 export function Badge({
-  variant = 'default',
-  size = 'md',
+  variant = "secondary",
+  size = "md",
+  statusColor = "info",
   className,
   children,
 }: BadgeProps) {
+  const colorClass =
+    variant === "status"
+      ? statusColorClasses[statusColor]
+      : variantClasses[variant];
+
   return (
     <span
       role="status"
       className={cn(
-        'inline-flex items-center gap-1 font-medium rounded-full',
-        'transition-[background-color,color] duration-[var(--transition-fast)]',
-        variantClasses[variant],
+        "inline-flex items-center gap-1 font-medium rounded-full",
+        "transition-[background-color,color] duration-[var(--transition-fast)]",
+        colorClass,
         sizeClasses[size],
         className,
       )}
     >
-      {variant === 'live' && <LiveDot />}
-      {variant === 'rating' && <StarIcon />}
+      {variant === "live" && <LiveDot />}
+      {variant === "rating" && <StarIcon />}
       {children}
     </span>
   );

--- a/src/design-system/primitives/Button.tsx
+++ b/src/design-system/primitives/Button.tsx
@@ -3,23 +3,29 @@ import {
   type ElementType,
   type ComponentPropsWithRef,
   forwardRef,
-} from 'react';
-import { cn } from '@/shared/utils/cn';
+} from "react";
+import { cn } from "@/shared/utils/cn";
+import { useFocusStyles } from "../focus/useFocusStyles";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'icon';
-export type ButtonSize = 'sm' | 'md' | 'lg';
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "icon";
+export type ButtonSize = "sm" | "md" | "lg";
 
 type PolymorphicProps<T extends ElementType> = {
   as?: T;
   variant?: ButtonVariant;
   size?: ButtonSize;
+  /** TV / D-pad spatial nav focus — applies TV-optimised focus ring visible at 10ft */
+  isTVFocused?: boolean;
   className?: string;
   children?: React.ReactNode;
-} & Omit<ComponentPropsWithRef<T>, 'as' | 'variant' | 'size' | 'className' | 'children'>;
+} & Omit<
+  ComponentPropsWithRef<T>,
+  "as" | "variant" | "size" | "className" | "children"
+>;
 
 // ---------------------------------------------------------------------------
 // Style maps
@@ -27,74 +33,79 @@ type PolymorphicProps<T extends ElementType> = {
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary: [
-    'bg-accent-teal text-bg-primary font-semibold',
-    'hover-capable:bg-accent-teal-dim',
-    'active:scale-[0.97]',
-    'disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary',
-  ].join(' '),
+    "bg-accent-teal text-bg-primary font-semibold",
+    "hover-capable:bg-accent-teal-dim",
+    "active:scale-[0.97]",
+    "disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary",
+  ].join(" "),
 
   secondary: [
-    'bg-bg-tertiary text-text-primary border border-white/10 font-medium',
-    'hover-capable:bg-bg-hover',
-    'active:scale-[0.97]',
-    'disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary',
-  ].join(' '),
+    "bg-bg-tertiary text-text-primary border border-white/10 font-medium",
+    "hover-capable:bg-bg-hover",
+    "active:scale-[0.97]",
+    "disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary",
+  ].join(" "),
 
   ghost: [
-    'bg-transparent text-text-secondary font-medium',
-    'hover-capable:bg-bg-hover hover-capable:text-text-primary',
-    'active:scale-[0.97]',
-    'disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary',
-  ].join(' '),
+    "bg-transparent text-text-secondary font-medium",
+    "hover-capable:bg-bg-hover hover-capable:text-text-primary",
+    "active:scale-[0.97]",
+    "disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary",
+  ].join(" "),
 
   icon: [
-    'bg-transparent text-text-secondary',
-    'hover-capable:bg-bg-hover hover-capable:text-text-primary',
-    'active:scale-[0.95]',
-    'disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary',
-    'p-2 rounded-full',
-  ].join(' '),
+    "bg-transparent text-text-secondary",
+    "hover-capable:bg-bg-hover hover-capable:text-text-primary",
+    "active:scale-[0.95]",
+    "disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary",
+    "p-2 rounded-full",
+  ].join(" "),
 };
 
 const sizeClasses: Record<ButtonSize, string> = {
-  sm: 'px-3 py-1.5 text-xs rounded-[var(--radius-sm)]',
-  md: 'px-4 py-2 text-sm rounded-[var(--radius-md)]',
-  lg: 'px-6 py-2.5 text-base rounded-[var(--radius-lg)]',
+  sm: "px-3 py-1.5 text-xs rounded-[var(--radius-sm)]",
+  md: "px-4 py-2 text-sm rounded-[var(--radius-md)]",
+  lg: "px-6 py-2.5 text-base rounded-[var(--radius-lg)]",
 };
 
 // Icon variant ignores size padding (has its own p-2 in variant classes)
 const iconSizeClasses: Record<ButtonSize, string> = {
-  sm: 'text-xs rounded-[var(--radius-sm)]',
-  md: 'text-sm rounded-full',
-  lg: 'text-base rounded-full',
+  sm: "text-xs rounded-[var(--radius-sm)]",
+  md: "text-sm rounded-full",
+  lg: "text-base rounded-full",
 };
 
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
-export const Button = forwardRef(function Button<T extends ElementType = 'button'>(
+export const Button = forwardRef(function Button<
+  T extends ElementType = "button",
+>(
   {
     as,
-    variant = 'primary',
-    size = 'md',
+    variant = "primary",
+    size = "md",
+    isTVFocused = false,
     className,
     children,
     ...props
   }: PolymorphicProps<T>,
   ref: React.ForwardedRef<HTMLElement>,
 ) {
-  const Tag = (as ?? 'button') as ElementType;
+  const Tag = (as ?? "button") as ElementType;
+  const focusStyles = useFocusStyles();
 
-  const sizeStyle = variant === 'icon' ? iconSizeClasses[size] : sizeClasses[size];
+  const sizeStyle =
+    variant === "icon" ? iconSizeClasses[size] : sizeClasses[size];
 
   const defaultButtonProps =
-    Tag === 'button'
-      ? ({ type: 'button' } as ButtonHTMLAttributes<HTMLButtonElement>)
+    Tag === "button"
+      ? ({ type: "button" } as ButtonHTMLAttributes<HTMLButtonElement>)
       : {};
 
   return (
@@ -103,19 +114,21 @@ export const Button = forwardRef(function Button<T extends ElementType = 'button
       {...defaultButtonProps}
       {...props}
       className={cn(
-        'inline-flex items-center justify-center gap-2',
-        'transition-[background-color,border-color,color,transform] duration-[var(--transition-fast)]',
-        'cursor-pointer select-none',
+        "inline-flex items-center justify-center gap-2",
+        "transition-[background-color,border-color,color,transform,box-shadow] duration-[var(--transition-fast)]",
+        "cursor-pointer select-none",
         variantClasses[variant],
         sizeStyle,
+        // TV D-pad focus: thick ring + ambient glow, readable at 10-foot distance
+        isTVFocused && focusStyles.buttonFocus,
         className,
       )}
     >
       {children}
     </Tag>
   );
-}) as <T extends ElementType = 'button'>(
+}) as <T extends ElementType = "button">(
   props: PolymorphicProps<T> & { ref?: React.ForwardedRef<HTMLElement> },
 ) => React.ReactElement;
 
-(Button as { displayName?: string }).displayName = 'Button';
+(Button as { displayName?: string }).displayName = "Button";

--- a/src/design-system/primitives/Input.tsx
+++ b/src/design-system/primitives/Input.tsx
@@ -1,0 +1,123 @@
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
+import { cn } from "@/shared/utils/cn";
+import { useFocusStyles } from "../focus/useFocusStyles";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type InputState = "default" | "error";
+export type InputSize = "sm" | "md" | "lg";
+
+export interface InputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "size"
+> {
+  /** Visual state — drives border/ring color */
+  state?: InputState;
+  size?: InputSize;
+  /** Error message shown below the field when state="error" */
+  errorMessage?: string;
+  /** Label rendered above the input */
+  label?: string;
+  /** Icon or adornment placed at the start (left) of the input */
+  startAdornment?: ReactNode;
+  /** TV / D-pad spatial nav focus — applies TV-optimised focus ring visible at 10ft */
+  isTVFocused?: boolean;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Style maps (new design-system tokens only — zero old CSS)
+// ---------------------------------------------------------------------------
+
+const sizeClasses: Record<InputSize, string> = {
+  sm: "px-3 py-1.5 text-xs rounded-[var(--radius-sm)]",
+  md: "px-3.5 py-2 text-sm rounded-[var(--radius-md)]",
+  lg: "px-4 py-2.5 text-base rounded-[var(--radius-lg)]",
+};
+
+const stateClasses: Record<InputState, string> = {
+  default: "border-border focus:border-accent-teal focus:ring-accent-teal",
+  error: "border-error focus:border-error focus:ring-error",
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  {
+    state = "default",
+    size = "md",
+    errorMessage,
+    label,
+    startAdornment,
+    isTVFocused = false,
+    id,
+    className,
+    disabled,
+    ...props
+  },
+  ref,
+) {
+  const focusStyles = useFocusStyles();
+  const inputId =
+    id ?? (label ? label.toLowerCase().replace(/\s+/g, "-") : undefined);
+
+  return (
+    <div className="flex flex-col gap-1.5 w-full">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="text-xs font-medium text-text-secondary uppercase tracking-wide"
+        >
+          {label}
+        </label>
+      )}
+
+      <div className="relative flex items-center">
+        {startAdornment && (
+          <span className="absolute left-3 flex items-center text-text-tertiary pointer-events-none">
+            {startAdornment}
+          </span>
+        )}
+
+        <input
+          ref={ref}
+          id={inputId}
+          disabled={disabled}
+          {...props}
+          className={cn(
+            // Base
+            "w-full bg-bg-secondary text-text-primary placeholder:text-text-muted",
+            "border outline-none",
+            "transition-[border-color,box-shadow] duration-[var(--transition-fast)]",
+            // Focus (keyboard / pointer)
+            "focus:outline-none focus:ring-2 focus:ring-offset-0",
+            // Size
+            sizeClasses[size],
+            // State-driven border/ring
+            stateClasses[state],
+            // Start adornment indent
+            startAdornment && "pl-9",
+            // Disabled
+            disabled &&
+              "opacity-50 cursor-not-allowed bg-bg-tertiary text-text-tertiary",
+            // TV D-pad focus overlay
+            isTVFocused && focusStyles.inputFocus,
+            className,
+          )}
+        />
+      </div>
+
+      {state === "error" && errorMessage && (
+        <p role="alert" className="text-xs text-error mt-0.5">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+});
+
+Input.displayName = "Input";

--- a/src/design-system/primitives/Toggle.tsx
+++ b/src/design-system/primitives/Toggle.tsx
@@ -1,0 +1,152 @@
+import { type InputHTMLAttributes, forwardRef, useId } from "react";
+import { cn } from "@/shared/utils/cn";
+import { useFocusStyles } from "../focus/useFocusStyles";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ToggleSize = "sm" | "md" | "lg";
+
+export interface ToggleProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "size" | "type"
+> {
+  /** Controlled checked state */
+  checked?: boolean;
+  /** Accessible label — rendered visually next to the toggle */
+  label?: string;
+  /** Hide the label visually (still accessible via aria-label) */
+  hideLabel?: boolean;
+  size?: ToggleSize;
+  /** TV / D-pad spatial nav focus — applies TV-optimised focus ring visible at 10ft */
+  isTVFocused?: boolean;
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Size tokens
+// ---------------------------------------------------------------------------
+
+const trackSize: Record<
+  ToggleSize,
+  { track: string; thumb: string; thumbOn: string }
+> = {
+  sm: {
+    track: "w-8 h-4",
+    thumb: "w-3 h-3 top-0.5 left-0.5",
+    thumbOn: "translate-x-4",
+  },
+  md: {
+    track: "w-11 h-6",
+    thumb: "w-5 h-5 top-0.5 left-0.5",
+    thumbOn: "translate-x-5",
+  },
+  lg: {
+    track: "w-14 h-7",
+    thumb: "w-6 h-6 top-0.5 left-0.5",
+    thumbOn: "translate-x-7",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Toggle
+ *
+ * Accessible on/off switch backed by a visually-hidden <input type="checkbox">.
+ * Supports keyboard (Space/Enter), pointer, and TV D-pad (isTVFocused prop).
+ *
+ * Animation: thumb slides with `transition-transform duration-200 ease-out`
+ * TV focus: thick teal ring via useFocusStyles().buttonFocus, readable at 10ft.
+ */
+export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(function Toggle(
+  {
+    checked,
+    label,
+    hideLabel = false,
+    size = "md",
+    isTVFocused = false,
+    disabled,
+    id,
+    className,
+    onChange,
+    ...props
+  },
+  ref,
+) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const focusStyles = useFocusStyles();
+  const { track, thumb, thumbOn } = trackSize[size];
+
+  return (
+    <label
+      htmlFor={inputId}
+      className={cn(
+        "inline-flex items-center gap-2.5 select-none",
+        disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+        className,
+      )}
+    >
+      {/* Visually hidden native checkbox — drives accessibility */}
+      <input
+        ref={ref}
+        id={inputId}
+        type="checkbox"
+        role="switch"
+        aria-checked={checked}
+        checked={checked}
+        disabled={disabled}
+        onChange={onChange}
+        className="sr-only"
+        {...props}
+      />
+
+      {/* Track */}
+      <span
+        aria-hidden="true"
+        className={cn(
+          "relative inline-block rounded-full shrink-0",
+          "transition-[background-color,box-shadow] duration-[var(--transition-normal)]",
+          track,
+          // Off state: subtle surface
+          "bg-bg-tertiary border border-border",
+          // On state: teal fill
+          checked && "bg-accent-teal border-accent-teal",
+          // TV focus ring
+          isTVFocused && focusStyles.buttonFocus,
+        )}
+      >
+        {/* Thumb */}
+        <span
+          className={cn(
+            "absolute rounded-full bg-text-primary shadow-sm",
+            "transition-transform duration-200 ease-out",
+            thumb,
+            checked && thumbOn,
+          )}
+        />
+      </span>
+
+      {/* Label */}
+      {label && (
+        <span
+          className={cn(
+            "text-text-primary font-medium",
+            size === "sm" && "text-xs",
+            size === "md" && "text-sm",
+            size === "lg" && "text-base",
+            hideLabel && "sr-only",
+          )}
+        >
+          {label}
+        </span>
+      )}
+    </label>
+  );
+});
+
+Toggle.displayName = "Toggle";

--- a/src/design-system/primitives/__tests__/Badge.test.tsx
+++ b/src/design-system/primitives/__tests__/Badge.test.tsx
@@ -1,107 +1,161 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { Badge, type BadgeVariant, type BadgeSize } from '../Badge';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Badge, type BadgeVariant, type BadgeSize } from "../Badge";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-function renderBadge(props?: React.ComponentPropsWithRef<typeof Badge>, children = 'Label') {
+function renderBadge(
+  props?: React.ComponentPropsWithRef<typeof Badge>,
+  children = "Label",
+) {
   return render(<Badge {...props}>{children}</Badge>);
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
-describe('Badge — variants', () => {
-  const variants: BadgeVariant[] = ['default', 'new', 'live', 'rating'];
+describe("Badge — variants", () => {
+  const variants: BadgeVariant[] = [
+    "primary",
+    "secondary",
+    "new",
+    "live",
+    "rating",
+  ];
 
-  it.each(variants)('renders the %s variant without crashing', (variant) => {
+  it.each(variants)("renders the %s variant without crashing", (variant) => {
     const { container } = renderBadge({ variant });
-    expect(container.querySelector('span')).toBeTruthy();
+    expect(container.querySelector("span")).toBeTruthy();
   });
 
-  it('default variant uses secondary text/background classes', () => {
-    const { container } = renderBadge({ variant: 'default' });
-    const el = container.querySelector('span')!;
-    expect(el.className).toContain('bg-bg-tertiary');
-    expect(el.className).toContain('text-text-secondary');
+  it("secondary variant uses bg-bg-tertiary and border-border classes", () => {
+    const { container } = renderBadge({ variant: "secondary" });
+    const el = container.querySelector("span")!;
+    expect(el.className).toContain("bg-bg-tertiary");
+    expect(el.className).toContain("border-border");
   });
 
-  it('new variant uses accent-teal classes', () => {
-    const { container } = renderBadge({ variant: 'new' });
-    const el = container.querySelector('span')!;
-    expect(el.className).toContain('bg-accent-teal');
-    expect(el.className).toContain('text-accent-teal');
+  it("new variant uses accent-teal classes", () => {
+    const { container } = renderBadge({ variant: "new" });
+    const el = container.querySelector("span")!;
+    expect(el.className).toContain("bg-accent-teal");
+    expect(el.className).toContain("text-accent-teal");
   });
 
-  it('live variant uses error classes', () => {
-    const { container } = renderBadge({ variant: 'live' });
-    const el = container.querySelector('span')!;
-    expect(el.className).toContain('bg-error');
-    expect(el.className).toContain('text-error');
+  it("live variant uses error classes", () => {
+    const { container } = renderBadge({ variant: "live" });
+    const el = container.querySelector("span")!;
+    expect(el.className).toContain("bg-error");
+    expect(el.className).toContain("text-error");
   });
 
-  it('rating variant uses warning classes', () => {
-    const { container } = renderBadge({ variant: 'rating' });
-    const el = container.querySelector('span')!;
-    expect(el.className).toContain('bg-warning');
-    expect(el.className).toContain('text-warning');
+  it("rating variant uses warning classes", () => {
+    const { container } = renderBadge({ variant: "rating" });
+    const el = container.querySelector("span")!;
+    expect(el.className).toContain("bg-warning");
+    expect(el.className).toContain("text-warning");
   });
 });
 
-describe('Badge — live variant pulsing dot', () => {
-  it('renders a pulsing dot for the live variant', () => {
-    const { container } = renderBadge({ variant: 'live' });
+describe("Badge — live variant pulsing dot", () => {
+  it("renders a pulsing dot for the live variant", () => {
+    const { container } = renderBadge({ variant: "live" });
     // The LiveDot is an aria-hidden span with rounded-full + bg-error
     const dot = container.querySelector('span[aria-hidden="true"]');
     expect(dot).not.toBeNull();
-    expect(dot!.className).toContain('rounded-full');
-    expect(dot!.className).toContain('bg-error');
+    expect(dot!.className).toContain("rounded-full");
+    expect(dot!.className).toContain("bg-error");
   });
 
-  it('does NOT render a pulsing dot for non-live variants', () => {
-    const { container } = renderBadge({ variant: 'new' });
+  it("does NOT render a pulsing dot for non-live variants", () => {
+    const { container } = renderBadge({ variant: "new" });
     const dot = container.querySelector('span[aria-hidden="true"]');
     expect(dot).toBeNull();
   });
 });
 
-describe('Badge — rating variant star icon', () => {
-  it('renders an SVG star icon for the rating variant', () => {
-    const { container } = renderBadge({ variant: 'rating' }, '8.5');
+describe("Badge — rating variant star icon", () => {
+  it("renders an SVG star icon for the rating variant", () => {
+    const { container } = renderBadge({ variant: "rating" }, "8.5");
     const svg = container.querySelector('svg[aria-hidden="true"]');
     expect(svg).not.toBeNull();
   });
 
-  it('does NOT render an SVG star icon for non-rating variants', () => {
-    const { container } = renderBadge({ variant: 'new' });
+  it("does NOT render an SVG star icon for non-rating variants", () => {
+    const { container } = renderBadge({ variant: "new" });
     const svg = container.querySelector('svg[aria-hidden="true"]');
     expect(svg).toBeNull();
   });
 });
 
-describe('Badge — sizes', () => {
-  const sizes: BadgeSize[] = ['sm', 'md'];
+describe("Badge — sizes", () => {
+  const sizes: BadgeSize[] = ["sm", "md"];
 
-  it.each(sizes)('renders the %s size without crashing', (size) => {
+  it.each(sizes)("renders the %s size without crashing", (size) => {
     const { container } = renderBadge({ size });
-    expect(container.querySelector('span')).toBeTruthy();
+    expect(container.querySelector("span")).toBeTruthy();
   });
 
-  it('sm size uses text-xs', () => {
-    const { container } = renderBadge({ size: 'sm' });
-    const el = container.querySelector('span')!;
-    expect(el.className).toContain('text-xs');
+  it("sm size uses text-xs", () => {
+    const { container } = renderBadge({ size: "sm" });
+    const el = container.querySelector("span")!;
+    expect(el.className).toContain("text-xs");
   });
 
-  it('md size uses text-sm', () => {
-    const { container } = renderBadge({ size: 'md' });
-    const el = container.querySelector('span')!;
-    expect(el.className).toContain('text-sm');
+  it("md size uses text-sm", () => {
+    const { container } = renderBadge({ size: "md" });
+    const el = container.querySelector("span")!;
+    expect(el.className).toContain("text-sm");
   });
 });
 
-describe('Badge — children', () => {
-  it('renders its children', () => {
-    renderBadge({}, 'NEW');
-    expect(screen.getByText('NEW')).toBeTruthy();
+describe("Badge — children", () => {
+  it("renders its children", () => {
+    renderBadge({}, "NEW");
+    expect(screen.getByText("NEW")).toBeTruthy();
+  });
+});
+
+describe("Badge — new variants (primary, secondary, status)", () => {
+  it("primary variant uses accent-teal classes", () => {
+    const { container } = renderBadge({ variant: "primary" });
+    const el = container.querySelector("span")!;
+    expect(el.className).toContain("bg-accent-teal");
+    expect(el.className).toContain("text-accent-teal");
+  });
+
+  it("secondary variant uses bg-bg-tertiary and border-border classes", () => {
+    const { container } = renderBadge({ variant: "secondary" });
+    const el = container.querySelector("span")!;
+    expect(el.className).toContain("bg-bg-tertiary");
+    expect(el.className).toContain("border-border");
+  });
+
+  it("status variant with statusColor=success uses success classes", () => {
+    const { container } = renderBadge({
+      variant: "status",
+      statusColor: "success",
+    });
+    const el = container.querySelector("span")!;
+    expect(el.className).toContain("bg-success");
+    expect(el.className).toContain("text-success");
+  });
+
+  it("status variant with statusColor=error uses error classes", () => {
+    const { container } = renderBadge({
+      variant: "status",
+      statusColor: "error",
+    });
+    const el = container.querySelector("span")!;
+    expect(el.className).toContain("bg-error");
+    expect(el.className).toContain("text-error");
+  });
+});
+
+describe("Badge — lg size", () => {
+  it("lg size uses text-base and px-3", () => {
+    const { container } = renderBadge({ size: "lg" });
+    const el = container.querySelector("span")!;
+    expect(el.className).toContain("text-base");
+    expect(el.className).toContain("px-3");
   });
 });

--- a/src/design-system/primitives/__tests__/Button.test.tsx
+++ b/src/design-system/primitives/__tests__/Button.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { createRef } from 'react';
-import { Button, type ButtonVariant } from '../Button';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { Button, type ButtonVariant } from "../Button";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -11,86 +11,110 @@ function renderButton(props?: Parameters<typeof Button>[0]) {
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
-describe('Button — variants', () => {
-  const variants: ButtonVariant[] = ['primary', 'secondary', 'ghost', 'icon'];
+describe("Button — variants", () => {
+  const variants: ButtonVariant[] = ["primary", "secondary", "ghost", "icon"];
 
-  it.each(variants)('renders the %s variant without crashing', (variant) => {
+  it.each(variants)("renders the %s variant without crashing", (variant) => {
     renderButton({ variant });
-    expect(screen.getByRole('button')).toBeTruthy();
+    expect(screen.getByRole("button")).toBeTruthy();
   });
 
-  it('primary variant includes accent-teal class', () => {
-    renderButton({ variant: 'primary' });
-    expect(screen.getByRole('button').className).toContain('bg-accent-teal');
+  it("primary variant includes accent-teal class", () => {
+    renderButton({ variant: "primary" });
+    expect(screen.getByRole("button").className).toContain("bg-accent-teal");
   });
 
-  it('secondary variant includes bg-bg-tertiary class', () => {
-    renderButton({ variant: 'secondary' });
-    expect(screen.getByRole('button').className).toContain('bg-bg-tertiary');
+  it("secondary variant includes bg-bg-tertiary class", () => {
+    renderButton({ variant: "secondary" });
+    expect(screen.getByRole("button").className).toContain("bg-bg-tertiary");
   });
 
-  it('ghost variant is transparent', () => {
-    renderButton({ variant: 'ghost' });
-    expect(screen.getByRole('button').className).toContain('bg-transparent');
+  it("ghost variant is transparent", () => {
+    renderButton({ variant: "ghost" });
+    expect(screen.getByRole("button").className).toContain("bg-transparent");
   });
 
-  it('icon variant has rounded-full and p-2 padding', () => {
-    renderButton({ variant: 'icon' });
-    const el = screen.getByRole('button');
-    expect(el.className).toContain('rounded-full');
-    expect(el.className).toContain('p-2');
+  it("icon variant has rounded-full and p-2 padding", () => {
+    renderButton({ variant: "icon" });
+    const el = screen.getByRole("button");
+    expect(el.className).toContain("rounded-full");
+    expect(el.className).toContain("p-2");
   });
 });
 
-describe('Button — as prop (polymorphic)', () => {
+describe("Button — as prop (polymorphic)", () => {
   it('renders as an <a> element when as="a" is passed', () => {
-    const { container } = render(<Button as="a" href="/test">Link</Button>);
-    const el = container.querySelector('a')!;
+    const { container } = render(
+      <Button as="a" href="/test">
+        Link
+      </Button>,
+    );
+    const el = container.querySelector("a")!;
     expect(el).toBeTruthy();
-    expect(el.tagName).toBe('A');
-    expect(el.getAttribute('href')).toContain('/test');
+    expect(el.tagName).toBe("A");
+    expect(el.getAttribute("href")).toContain("/test");
   });
 
   it('renders as a <span> element when as="span" is passed', () => {
     const { container } = render(<Button as="span">Span</Button>);
-    expect(container.querySelector('span')).toBeTruthy();
+    expect(container.querySelector("span")).toBeTruthy();
   });
 });
 
-describe('Button — disabled', () => {
-  it('has disabled attribute when disabled prop is passed', () => {
+describe("Button — disabled", () => {
+  it("has disabled attribute when disabled prop is passed", () => {
     renderButton({ disabled: true });
-    const el = screen.getByRole('button') as HTMLButtonElement;
+    const el = screen.getByRole("button") as HTMLButtonElement;
     expect(el.disabled).toBe(true);
   });
 
-  it('applies disabled CSS utility classes when disabled', () => {
+  it("applies disabled CSS utility classes when disabled", () => {
     renderButton({ disabled: true });
-    const el = screen.getByRole('button');
-    expect(el.className).toContain('disabled:opacity-50');
-    expect(el.className).toContain('disabled:cursor-not-allowed');
+    const el = screen.getByRole("button");
+    expect(el.className).toContain("disabled:opacity-50");
+    expect(el.className).toContain("disabled:cursor-not-allowed");
   });
 });
 
-describe('Button — default type', () => {
+describe("Button — default type", () => {
   it('adds type="button" for button elements to prevent accidental form submission', () => {
     renderButton();
-    const el = screen.getByRole('button') as HTMLButtonElement;
-    expect(el.type).toBe('button');
+    const el = screen.getByRole("button") as HTMLButtonElement;
+    expect(el.type).toBe("button");
   });
 
   it('does NOT add type="button" when rendered as a non-button element', () => {
     const { container } = render(<Button as="a">Link</Button>);
-    const el = container.querySelector('a')!;
-    expect(el.getAttribute('type')).toBeNull();
+    const el = container.querySelector("a")!;
+    expect(el.getAttribute("type")).toBeNull();
   });
 });
 
-describe('Button — ref forwarding', () => {
-  it('forwards ref to the underlying DOM element', () => {
+describe("Button — ref forwarding", () => {
+  it("forwards ref to the underlying DOM element", () => {
     const ref = createRef<HTMLButtonElement>();
     render(<Button ref={ref}>Ref test</Button>);
     expect(ref.current).not.toBeNull();
-    expect(ref.current?.tagName).toBe('BUTTON');
+    expect(ref.current?.tagName).toBe("BUTTON");
+  });
+});
+
+describe("Button — TV focus (isTVFocused)", () => {
+  it("applies teal ring class when isTVFocused=true", () => {
+    renderButton({ isTVFocused: true });
+    const el = screen.getByRole("button");
+    expect(el.className).toContain("ring-");
+    expect(el.className).toContain("accent-teal");
+  });
+
+  it("does NOT apply isTVFocused ring when isTVFocused=false", () => {
+    renderButton({ isTVFocused: false });
+    // No manually-applied TV focus ring; focus-visible ring is CSS-only
+    expect(screen.getByRole("button").className).not.toContain("ring-[3px]");
+  });
+
+  it("includes box-shadow in transition property for smooth TV ring animation", () => {
+    renderButton();
+    expect(screen.getByRole("button").className).toContain("box-shadow");
   });
 });

--- a/src/design-system/primitives/__tests__/Input.test.tsx
+++ b/src/design-system/primitives/__tests__/Input.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Input } from "../Input";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function renderInput(props?: React.ComponentPropsWithRef<typeof Input>) {
+  return render(<Input placeholder="Type here" {...props} />);
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("Input — default state", () => {
+  it("renders an input element", () => {
+    renderInput();
+    expect(screen.getByRole("textbox")).toBeTruthy();
+  });
+
+  it("uses bg-bg-secondary token by default", () => {
+    renderInput();
+    expect(screen.getByRole("textbox").className).toContain("bg-bg-secondary");
+  });
+
+  it("applies default border-border token", () => {
+    renderInput();
+    expect(screen.getByRole("textbox").className).toContain("border-border");
+  });
+});
+
+describe("Input — error state", () => {
+  it("applies error border token when state=error", () => {
+    renderInput({ state: "error" });
+    expect(screen.getByRole("textbox").className).toContain("border-error");
+  });
+
+  it("renders error message when state=error and errorMessage provided", () => {
+    renderInput({ state: "error", errorMessage: "Field is required" });
+    expect(screen.getByRole("alert").textContent).toBe("Field is required");
+  });
+
+  it("does NOT render error message when state=default", () => {
+    renderInput({ state: "default", errorMessage: "Should not show" });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+describe("Input — disabled state", () => {
+  it("has disabled attribute when disabled prop is set", () => {
+    renderInput({ disabled: true });
+    const el = screen.getByRole("textbox") as HTMLInputElement;
+    expect(el.disabled).toBe(true);
+  });
+
+  it("applies opacity-50 and cursor-not-allowed when disabled", () => {
+    renderInput({ disabled: true });
+    expect(screen.getByRole("textbox").className).toContain("opacity-50");
+    expect(screen.getByRole("textbox").className).toContain(
+      "cursor-not-allowed",
+    );
+  });
+});
+
+describe("Input — label", () => {
+  it("renders a label element when label prop is provided", () => {
+    renderInput({ label: "Email" });
+    expect(screen.getByText("Email")).toBeTruthy();
+  });
+
+  it("associates label with input via htmlFor", () => {
+    const { container } = renderInput({ label: "Username", id: "username" });
+    const label = container.querySelector("label");
+    expect(label?.getAttribute("for")).toBe("username");
+  });
+});
+
+describe("Input — TV focus", () => {
+  it("applies TV focus ring class when isTVFocused=true", () => {
+    renderInput({ isTVFocused: true });
+    // useFocusStyles returns ring-[3px] ring-accent-teal in TV mode (isTVMode=false in test env → ring-2)
+    const el = screen.getByRole("textbox");
+    expect(el.className).toContain("ring-");
+    expect(el.className).toContain("accent-teal");
+  });
+
+  it("does NOT apply TV focus ring when isTVFocused=false", () => {
+    renderInput({ isTVFocused: false });
+    // No isTVFocused ring-[3px] applied outside focus-visible
+    expect(screen.getByRole("textbox").className).not.toContain("ring-[3px]");
+  });
+});
+
+describe("Input — sizes", () => {
+  it("sm size uses text-xs", () => {
+    renderInput({ size: "sm" });
+    expect(screen.getByRole("textbox").className).toContain("text-xs");
+  });
+
+  it("lg size uses text-base", () => {
+    renderInput({ size: "lg" });
+    expect(screen.getByRole("textbox").className).toContain("text-base");
+  });
+});

--- a/src/design-system/primitives/__tests__/Toggle.test.tsx
+++ b/src/design-system/primitives/__tests__/Toggle.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Toggle } from "../Toggle";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function renderToggle(props?: React.ComponentPropsWithRef<typeof Toggle>) {
+  return render(<Toggle label="Enable feature" {...props} />);
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("Toggle — rendering", () => {
+  it("renders a checkbox with role=switch", () => {
+    renderToggle();
+    expect(screen.getByRole("switch")).toBeTruthy();
+  });
+
+  it("renders label text", () => {
+    renderToggle({ label: "Dark mode" });
+    expect(screen.getByText("Dark mode")).toBeTruthy();
+  });
+
+  it("hides label visually when hideLabel=true but keeps it accessible", () => {
+    renderToggle({ label: "Dark mode", hideLabel: true });
+    const labelEl = screen.getByText("Dark mode");
+    expect(labelEl.className).toContain("sr-only");
+  });
+});
+
+describe("Toggle — checked state", () => {
+  it("reflects checked=true on the input", () => {
+    renderToggle({ checked: true, onChange: vi.fn() });
+    const input = screen.getByRole("switch") as HTMLInputElement;
+    expect(input.checked).toBe(true);
+  });
+
+  it("reflects checked=false on the input", () => {
+    renderToggle({ checked: false, onChange: vi.fn() });
+    const input = screen.getByRole("switch") as HTMLInputElement;
+    expect(input.checked).toBe(false);
+  });
+
+  it("track applies bg-accent-teal when checked=true", () => {
+    const { container } = renderToggle({ checked: true, onChange: vi.fn() });
+    // The track is the aria-hidden span sibling to the sr-only input
+    const track = container.querySelector("span[aria-hidden='true']");
+    expect(track?.className).toContain("bg-accent-teal");
+  });
+
+  it("track does NOT apply bg-accent-teal when checked=false", () => {
+    const { container } = renderToggle({ checked: false, onChange: vi.fn() });
+    const track = container.querySelector("span[aria-hidden='true']");
+    expect(track?.className).not.toContain("bg-accent-teal");
+  });
+});
+
+describe("Toggle — disabled state", () => {
+  it("has disabled attribute when disabled=true", () => {
+    renderToggle({ disabled: true });
+    const input = screen.getByRole("switch") as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+  });
+
+  it("applies opacity-50 and cursor-not-allowed on the label when disabled", () => {
+    const { container } = renderToggle({ disabled: true });
+    const label = container.querySelector("label");
+    expect(label?.className).toContain("opacity-50");
+    expect(label?.className).toContain("cursor-not-allowed");
+  });
+});
+
+describe("Toggle — onChange", () => {
+  it("calls onChange when clicked", () => {
+    const onChange = vi.fn();
+    renderToggle({ onChange });
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("input has disabled attribute, preventing real interaction", () => {
+    // Verifies the disabled prop is forwarded to the underlying input.
+    // Native browser + real userEvent will not fire onChange on a disabled input;
+    // fireEvent bypasses native behaviour so we assert the attribute instead.
+    renderToggle({ disabled: true, onChange: vi.fn() });
+    expect((screen.getByRole("switch") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+  });
+});
+
+describe("Toggle — TV focus", () => {
+  it("applies TV focus ring on track when isTVFocused=true", () => {
+    const { container } = renderToggle({ isTVFocused: true });
+    const track = container.querySelector("span[aria-hidden='true']");
+    expect(track?.className).toContain("ring-");
+    expect(track?.className).toContain("accent-teal");
+  });
+});
+
+describe("Toggle — sizes", () => {
+  it("sm size applies w-8 track", () => {
+    const { container } = renderToggle({ size: "sm" });
+    const track = container.querySelector("span[aria-hidden='true']");
+    expect(track?.className).toContain("w-8");
+  });
+
+  it("lg size applies w-14 track", () => {
+    const { container } = renderToggle({ size: "lg" });
+    const track = container.querySelector("span[aria-hidden='true']");
+    expect(track?.className).toContain("w-14");
+  });
+});

--- a/src/design-system/primitives/index.ts
+++ b/src/design-system/primitives/index.ts
@@ -1,10 +1,25 @@
-export { Button } from './Button';
-export type { ButtonVariant, ButtonSize } from './Button';
+export { Button } from "./Button";
+export type { ButtonVariant, ButtonSize } from "./Button";
 
-export { Badge } from './Badge';
-export type { BadgeVariant, BadgeSize, BadgeProps } from './Badge';
+export { Badge } from "./Badge";
+export type {
+  BadgeVariant,
+  BadgeSize,
+  BadgeStatusColor,
+  BadgeProps,
+} from "./Badge";
 
-export { Skeleton, SkeletonText } from './Skeleton';
-export type { SkeletonProps, SkeletonRounded, SkeletonVariant } from './Skeleton';
+export { Input } from "./Input";
+export type { InputProps, InputState, InputSize } from "./Input";
 
-export { ToastContainer, useToast } from './Toast';
+export { Toggle } from "./Toggle";
+export type { ToggleProps, ToggleSize } from "./Toggle";
+
+export { Skeleton, SkeletonText } from "./Skeleton";
+export type {
+  SkeletonProps,
+  SkeletonRounded,
+  SkeletonVariant,
+} from "./Skeleton";
+
+export { ToastContainer, useToast } from "./Toast";

--- a/src/features/home/components/HeroBanner.tsx
+++ b/src/features/home/components/HeroBanner.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@/shared/utils/cn';
-import { Badge } from '@/design-system/primitives/Badge';
+import { cn } from "@/shared/utils/cn";
+import { Badge } from "@/design-system/primitives/Badge";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -78,7 +78,7 @@ export function HeroBanner({
         {genres && genres.length > 0 && (
           <div className="flex flex-wrap gap-1.5">
             {genres.map((genre) => (
-              <Badge key={genre} variant="default" size="sm">
+              <Badge key={genre} variant="secondary" size="sm">
                 {genre}
               </Badge>
             ))}
@@ -108,11 +108,11 @@ export function HeroBanner({
               type="button"
               onClick={onPlay}
               className={cn(
-                'inline-flex items-center gap-2 px-6 py-2.5',
-                'bg-accent-teal text-bg-primary font-semibold rounded-[var(--radius-md)]',
-                'transition-[background-color,transform] duration-200 ease-out',
-                'hover-capable:hover:bg-accent-teal/90 hover-capable:hover:scale-[1.02]',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary',
+                "inline-flex items-center gap-2 px-6 py-2.5",
+                "bg-accent-teal text-bg-primary font-semibold rounded-[var(--radius-md)]",
+                "transition-[background-color,transform] duration-200 ease-out",
+                "hover-capable:hover:bg-accent-teal/90 hover-capable:hover:scale-[1.02]",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-teal focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary",
               )}
             >
               <svg

--- a/src/routes/dev.design-system.lazy.tsx
+++ b/src/routes/dev.design-system.lazy.tsx
@@ -1,16 +1,16 @@
-import { createLazyFileRoute } from '@tanstack/react-router';
-import { useState } from 'react';
-import { Button } from '@/design-system/primitives/Button';
-import { Badge } from '@/design-system/primitives/Badge';
-import { Skeleton, SkeletonText } from '@/design-system/primitives/Skeleton';
-import { useToast } from '@/design-system/primitives/Toast';
-import { PosterCard } from '@/design-system/cards/PosterCard';
-import { LandscapeCard } from '@/design-system/cards/LandscapeCard';
-import { HeroCard } from '@/design-system/cards/HeroCard';
-import { FocusRing } from '@/design-system/focus/FocusRing';
-import { cn } from '@/shared/utils/cn';
+import { createLazyFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+import { Button } from "@/design-system/primitives/Button";
+import { Badge } from "@/design-system/primitives/Badge";
+import { Skeleton, SkeletonText } from "@/design-system/primitives/Skeleton";
+import { useToast } from "@/design-system/primitives/Toast";
+import { PosterCard } from "@/design-system/cards/PosterCard";
+import { LandscapeCard } from "@/design-system/cards/LandscapeCard";
+import { HeroCard } from "@/design-system/cards/HeroCard";
+import { FocusRing } from "@/design-system/focus/FocusRing";
+import { cn } from "@/shared/utils/cn";
 
-export const Route = createLazyFileRoute('/dev/design-system')({
+export const Route = createLazyFileRoute("/dev/design-system")({
   component: DesignSystemPage,
 });
 
@@ -77,7 +77,7 @@ function ColorSwatch({
     <div className="flex flex-col gap-1.5 min-w-[80px]">
       <div
         className={cn(
-          'h-14 w-full rounded-[var(--radius-md)] border border-white/8',
+          "h-14 w-full rounded-[var(--radius-md)] border border-white/8",
           bgClass,
         )}
         style={style}
@@ -158,7 +158,7 @@ function FocusRingDemo({
   variant,
   label,
 }: {
-  variant: 'card' | 'button' | 'input';
+  variant: "card" | "button" | "input";
   label: string;
 }) {
   const [focused, setFocused] = useState(false);
@@ -169,8 +169,8 @@ function FocusRingDemo({
         variant={variant}
         isFocused={focused}
         className={cn(
-          'rounded-[var(--radius-md)]',
-          variant === 'card' && 'rounded-[var(--radius-lg)]',
+          "rounded-[var(--radius-md)]",
+          variant === "card" && "rounded-[var(--radius-lg)]",
         )}
       >
         <button
@@ -180,12 +180,13 @@ function FocusRingDemo({
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
           className={cn(
-            'bg-bg-tertiary border border-white/10 text-text-secondary text-sm px-4 py-2',
-            'rounded-[var(--radius-md)] cursor-pointer',
-            variant === 'card' && 'w-24 h-32 rounded-[var(--radius-lg)] flex items-center justify-center text-xs',
+            "bg-bg-tertiary border border-white/10 text-text-secondary text-sm px-4 py-2",
+            "rounded-[var(--radius-md)] cursor-pointer",
+            variant === "card" &&
+              "w-24 h-32 rounded-[var(--radius-lg)] flex items-center justify-center text-xs",
           )}
         >
-          {variant === 'card' ? 'Card' : label}
+          {variant === "card" ? "Card" : label}
         </button>
       </FocusRing>
       <Label>{label} (hover to preview)</Label>
@@ -203,13 +204,12 @@ function DesignSystemPage() {
   return (
     <div className="bg-bg-primary min-h-screen">
       <div className="max-w-7xl mx-auto px-[var(--spacing-page-x)] py-12">
-
         {/* Page header */}
         <div className="mb-12 flex flex-col gap-3">
           <div className="flex items-center gap-3">
             <div
               className="w-2 h-8 rounded-full"
-              style={{ background: 'var(--gradient-brand)' }}
+              style={{ background: "var(--gradient-brand)" }}
               aria-hidden="true"
             />
             <h1 className="text-4xl font-bold text-text-primary font-[family-name:var(--font-family-heading)] tracking-tight">
@@ -217,18 +217,22 @@ function DesignSystemPage() {
             </h1>
           </div>
           <p className="text-text-secondary font-[family-name:var(--font-family-body)] max-w-2xl leading-relaxed">
-            Sprint 0 component showcase. All design tokens, primitives, cards, and
-            interaction patterns. Developer reference only — not user-facing.
+            Sprint 0 component showcase. All design tokens, primitives, cards,
+            and interaction patterns. Developer reference only — not
+            user-facing.
           </p>
           <div className="flex gap-2 mt-1">
-            <Badge variant="new" size="sm">Sprint 0</Badge>
-            <Badge variant="default" size="sm">Dev Tool</Badge>
+            <Badge variant="new" size="sm">
+              Sprint 0
+            </Badge>
+            <Badge variant="secondary" size="sm">
+              Dev Tool
+            </Badge>
           </div>
         </div>
 
         {/* Sections */}
         <div className="flex flex-col gap-16">
-
           {/* ----------------------------------------------------------------
               Color Tokens
           ---------------------------------------------------------------- */}
@@ -237,62 +241,152 @@ function DesignSystemPage() {
             description="All Tailwind @theme color variables. These map directly to bg-*, text-*, accent-*, status-* utility classes."
           >
             <div className="flex flex-col gap-8">
-
-              <SubSection title="Background" className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-4">
-                <ColorSwatch name="bg-primary" hex="#0a0a0f" style={{ background: '#0a0a0f' }} />
-                <ColorSwatch name="bg-secondary" hex="#141418" style={{ background: '#141418' }} />
-                <ColorSwatch name="bg-tertiary" hex="#1a1a22" style={{ background: '#1a1a22' }} />
-                <ColorSwatch name="bg-hover" hex="#1e1e28" style={{ background: '#1e1e28' }} />
-                <ColorSwatch name="bg-overlay" hex="rgba(10,10,15,.85)" style={{ background: 'rgba(10,10,15,0.85)' }} />
+              <SubSection
+                title="Background"
+                className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-4"
+              >
+                <ColorSwatch
+                  name="bg-primary"
+                  hex="#0a0a0f"
+                  style={{ background: "#0a0a0f" }}
+                />
+                <ColorSwatch
+                  name="bg-secondary"
+                  hex="#141418"
+                  style={{ background: "#141418" }}
+                />
+                <ColorSwatch
+                  name="bg-tertiary"
+                  hex="#1a1a22"
+                  style={{ background: "#1a1a22" }}
+                />
+                <ColorSwatch
+                  name="bg-hover"
+                  hex="#1e1e28"
+                  style={{ background: "#1e1e28" }}
+                />
+                <ColorSwatch
+                  name="bg-overlay"
+                  hex="rgba(10,10,15,.85)"
+                  style={{ background: "rgba(10,10,15,0.85)" }}
+                />
               </SubSection>
 
-              <SubSection title="Accent" className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-4">
-                <ColorSwatch name="accent-teal" hex="#14b8a6" style={{ background: '#14b8a6' }} />
-                <ColorSwatch name="accent-teal-dim" hex="#0d9488" style={{ background: '#0d9488' }} />
-                <ColorSwatch name="accent-indigo" hex="#6366f1" style={{ background: '#6366f1' }} />
-                <ColorSwatch name="accent-indigo-dim" hex="#4f46e5" style={{ background: '#4f46e5' }} />
+              <SubSection
+                title="Accent"
+                className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-4"
+              >
+                <ColorSwatch
+                  name="accent-teal"
+                  hex="#14b8a6"
+                  style={{ background: "#14b8a6" }}
+                />
+                <ColorSwatch
+                  name="accent-teal-dim"
+                  hex="#0d9488"
+                  style={{ background: "#0d9488" }}
+                />
+                <ColorSwatch
+                  name="accent-indigo"
+                  hex="#6366f1"
+                  style={{ background: "#6366f1" }}
+                />
+                <ColorSwatch
+                  name="accent-indigo-dim"
+                  hex="#4f46e5"
+                  style={{ background: "#4f46e5" }}
+                />
               </SubSection>
 
-              <SubSection title="Text" className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-4">
-                <ColorSwatch name="text-primary" hex="#f5f5f5" style={{ background: '#f5f5f5' }} />
-                <ColorSwatch name="text-secondary" hex="#94a3b8" style={{ background: '#94a3b8' }} />
-                <ColorSwatch name="text-tertiary" hex="#64748b" style={{ background: '#64748b' }} />
+              <SubSection
+                title="Text"
+                className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-4"
+              >
+                <ColorSwatch
+                  name="text-primary"
+                  hex="#f5f5f5"
+                  style={{ background: "#f5f5f5" }}
+                />
+                <ColorSwatch
+                  name="text-secondary"
+                  hex="#94a3b8"
+                  style={{ background: "#94a3b8" }}
+                />
+                <ColorSwatch
+                  name="text-tertiary"
+                  hex="#64748b"
+                  style={{ background: "#64748b" }}
+                />
               </SubSection>
 
-              <SubSection title="Status" className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-4">
-                <ColorSwatch name="success" hex="#22c55e" style={{ background: '#22c55e' }} />
-                <ColorSwatch name="warning" hex="#eab308" style={{ background: '#eab308' }} />
-                <ColorSwatch name="error" hex="#ef4444" style={{ background: '#ef4444' }} />
-                <ColorSwatch name="info" hex="#3b82f6" style={{ background: '#3b82f6' }} />
+              <SubSection
+                title="Status"
+                className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-4"
+              >
+                <ColorSwatch
+                  name="success"
+                  hex="#22c55e"
+                  style={{ background: "#22c55e" }}
+                />
+                <ColorSwatch
+                  name="warning"
+                  hex="#eab308"
+                  style={{ background: "#eab308" }}
+                />
+                <ColorSwatch
+                  name="error"
+                  hex="#ef4444"
+                  style={{ background: "#ef4444" }}
+                />
+                <ColorSwatch
+                  name="info"
+                  hex="#3b82f6"
+                  style={{ background: "#3b82f6" }}
+                />
               </SubSection>
 
-              <SubSection title="Gradients" className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4">
+              <SubSection
+                title="Gradients"
+                className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4"
+              >
                 <div className="flex flex-col gap-1.5">
                   <div
                     className="h-14 w-full rounded-[var(--radius-md)] border border-white/8"
-                    style={{ background: 'var(--gradient-brand)' }}
+                    style={{ background: "var(--gradient-brand)" }}
                     aria-hidden="true"
                   />
-                  <p className="text-xs font-mono text-text-primary">gradient-brand</p>
-                  <p className="text-xs font-mono text-text-tertiary">teal → indigo, 135°</p>
+                  <p className="text-xs font-mono text-text-primary">
+                    gradient-brand
+                  </p>
+                  <p className="text-xs font-mono text-text-tertiary">
+                    teal → indigo, 135°
+                  </p>
                 </div>
                 <div className="flex flex-col gap-1.5">
                   <div
                     className="h-14 w-full rounded-[var(--radius-md)] border border-white/8"
-                    style={{ background: 'var(--gradient-hero)' }}
+                    style={{ background: "var(--gradient-hero)" }}
                     aria-hidden="true"
                   />
-                  <p className="text-xs font-mono text-text-primary">gradient-hero</p>
-                  <p className="text-xs font-mono text-text-tertiary">bg-primary → transparent, top</p>
+                  <p className="text-xs font-mono text-text-primary">
+                    gradient-hero
+                  </p>
+                  <p className="text-xs font-mono text-text-tertiary">
+                    bg-primary → transparent, top
+                  </p>
                 </div>
                 <div className="flex flex-col gap-1.5">
                   <div
                     className="h-14 w-full rounded-[var(--radius-md)] border border-white/8"
-                    style={{ background: 'var(--gradient-card)' }}
+                    style={{ background: "var(--gradient-card)" }}
                     aria-hidden="true"
                   />
-                  <p className="text-xs font-mono text-text-primary">gradient-card</p>
-                  <p className="text-xs font-mono text-text-tertiary">bg-primary/90 → transparent, top</p>
+                  <p className="text-xs font-mono text-text-primary">
+                    gradient-card
+                  </p>
+                  <p className="text-xs font-mono text-text-tertiary">
+                    bg-primary/90 → transparent, top
+                  </p>
                 </div>
               </SubSection>
             </div>
@@ -306,24 +400,55 @@ function DesignSystemPage() {
             description="Satoshi (font-heading) for headings and UI labels. General Sans (font-body) for body copy and descriptions."
           >
             <div className="flex flex-col gap-10">
-
               <SubSection title="Satoshi — Heading Font">
                 <div className="flex flex-col gap-4 bg-bg-secondary rounded-[var(--radius-lg)] p-6 border border-white/6">
                   {[
-                    { size: 'text-4xl', label: '4xl / 2.5rem', sample: 'Pushpa 2: The Rule' },
-                    { size: 'text-3xl', label: '3xl / 2rem', sample: 'RRR — Rise, Roar, Revolt' },
-                    { size: 'text-2xl', label: '2xl / 1.5rem', sample: 'Baahubali: The Beginning' },
-                    { size: 'text-xl', label: 'xl / 1.25rem', sample: 'KGF Chapter 2' },
-                    { size: 'text-lg', label: 'lg / 1.125rem', sample: 'Kantara: A Legend' },
-                    { size: 'text-base', label: 'base / 1rem', sample: 'Vikram — A Lokesh Kanagaraj Film' },
-                    { size: 'text-sm', label: 'sm / 0.875rem', sample: 'All films, categories, and collections' },
-                    { size: 'text-xs', label: 'xs / 0.75rem', sample: 'Badge labels, metadata, timestamps' },
+                    {
+                      size: "text-4xl",
+                      label: "4xl / 2.5rem",
+                      sample: "Pushpa 2: The Rule",
+                    },
+                    {
+                      size: "text-3xl",
+                      label: "3xl / 2rem",
+                      sample: "RRR — Rise, Roar, Revolt",
+                    },
+                    {
+                      size: "text-2xl",
+                      label: "2xl / 1.5rem",
+                      sample: "Baahubali: The Beginning",
+                    },
+                    {
+                      size: "text-xl",
+                      label: "xl / 1.25rem",
+                      sample: "KGF Chapter 2",
+                    },
+                    {
+                      size: "text-lg",
+                      label: "lg / 1.125rem",
+                      sample: "Kantara: A Legend",
+                    },
+                    {
+                      size: "text-base",
+                      label: "base / 1rem",
+                      sample: "Vikram — A Lokesh Kanagaraj Film",
+                    },
+                    {
+                      size: "text-sm",
+                      label: "sm / 0.875rem",
+                      sample: "All films, categories, and collections",
+                    },
+                    {
+                      size: "text-xs",
+                      label: "xs / 0.75rem",
+                      sample: "Badge labels, metadata, timestamps",
+                    },
                   ].map(({ size, label, sample }) => (
                     <div key={label} className="flex items-baseline gap-4">
                       <span
                         className={cn(
                           size,
-                          'text-text-primary font-[family-name:var(--font-family-heading)] font-semibold leading-tight flex-1',
+                          "text-text-primary font-[family-name:var(--font-family-heading)] font-semibold leading-tight flex-1",
                         )}
                       >
                         {sample}
@@ -339,16 +464,34 @@ function DesignSystemPage() {
               <SubSection title="General Sans — Body Font">
                 <div className="flex flex-col gap-4 bg-bg-secondary rounded-[var(--radius-lg)] p-6 border border-white/6">
                   {[
-                    { size: 'text-lg', label: 'lg / 1.125rem', sample: 'Discover thousands of movies and TV shows.' },
-                    { size: 'text-base', label: 'base / 1rem', sample: 'Stream in HD quality. Available on all your devices.' },
-                    { size: 'text-sm', label: 'sm / 0.875rem', sample: 'Continue watching where you left off. Resuming from 42:30.' },
-                    { size: 'text-xs', label: 'xs / 0.75rem', sample: 'Action • Drama • 2h 19m • 2022 • Telugu' },
+                    {
+                      size: "text-lg",
+                      label: "lg / 1.125rem",
+                      sample: "Discover thousands of movies and TV shows.",
+                    },
+                    {
+                      size: "text-base",
+                      label: "base / 1rem",
+                      sample:
+                        "Stream in HD quality. Available on all your devices.",
+                    },
+                    {
+                      size: "text-sm",
+                      label: "sm / 0.875rem",
+                      sample:
+                        "Continue watching where you left off. Resuming from 42:30.",
+                    },
+                    {
+                      size: "text-xs",
+                      label: "xs / 0.75rem",
+                      sample: "Action • Drama • 2h 19m • 2022 • Telugu",
+                    },
                   ].map(({ size, label, sample }) => (
                     <div key={label} className="flex items-baseline gap-4">
                       <span
                         className={cn(
                           size,
-                          'text-text-secondary font-[family-name:var(--font-family-body)] leading-relaxed flex-1',
+                          "text-text-secondary font-[family-name:var(--font-family-body)] leading-relaxed flex-1",
                         )}
                       >
                         {sample}
@@ -379,8 +522,10 @@ function DesignSystemPage() {
             description="Spacing tokens are CSS custom properties for layout. Border-radius tokens define the corner style scale."
           >
             <div className="flex flex-col gap-10">
-
-              <SubSection title="Spacing Scale" className="flex flex-wrap gap-8 items-end">
+              <SubSection
+                title="Spacing Scale"
+                className="flex flex-wrap gap-8 items-end"
+              >
                 <SpacingBox size={4} label="4px" />
                 <SpacingBox size={8} label="8px" />
                 <SpacingBox size={12} label="12px" />
@@ -393,22 +538,41 @@ function DesignSystemPage() {
 
               <SubSection title="Layout Tokens" className="flex flex-col gap-2">
                 {[
-                  { name: '--spacing-page-x', value: 'clamp(1rem, 4vw, 3rem)', desc: 'Horizontal page padding' },
-                  { name: '--spacing-rail-gap', value: '0.75rem', desc: 'Gap between cards in a rail' },
-                  { name: '--spacing-section-gap', value: '2rem', desc: 'Vertical gap between page sections' },
+                  {
+                    name: "--spacing-page-x",
+                    value: "clamp(1rem, 4vw, 3rem)",
+                    desc: "Horizontal page padding",
+                  },
+                  {
+                    name: "--spacing-rail-gap",
+                    value: "0.75rem",
+                    desc: "Gap between cards in a rail",
+                  },
+                  {
+                    name: "--spacing-section-gap",
+                    value: "2rem",
+                    desc: "Vertical gap between page sections",
+                  },
                 ].map(({ name, value, desc }) => (
                   <div
                     key={name}
                     className="flex items-center gap-4 py-2.5 px-3 rounded-[var(--radius-sm)] bg-bg-tertiary border border-white/6"
                   >
-                    <code className="text-xs font-mono text-accent-teal shrink-0 w-52">{name}</code>
-                    <code className="text-xs font-mono text-text-secondary shrink-0 w-40">{value}</code>
+                    <code className="text-xs font-mono text-accent-teal shrink-0 w-52">
+                      {name}
+                    </code>
+                    <code className="text-xs font-mono text-text-secondary shrink-0 w-40">
+                      {value}
+                    </code>
                     <span className="text-xs text-text-tertiary">{desc}</span>
                   </div>
                 ))}
               </SubSection>
 
-              <SubSection title="Border Radius Scale" className="flex flex-wrap gap-6 items-end">
+              <SubSection
+                title="Border Radius Scale"
+                className="flex flex-wrap gap-6 items-end"
+              >
                 <RadiusBox label="--radius-sm (6px)" cssVar="--radius-sm" />
                 <RadiusBox label="--radius-md (8px)" cssVar="--radius-md" />
                 <RadiusBox label="--radius-lg (12px)" cssVar="--radius-lg" />
@@ -434,27 +598,35 @@ function DesignSystemPage() {
             <div className="flex flex-col gap-8">
               {(
                 [
-                  { variant: 'primary', label: 'Primary' },
-                  { variant: 'secondary', label: 'Secondary' },
-                  { variant: 'ghost', label: 'Ghost' },
+                  { variant: "primary", label: "Primary" },
+                  { variant: "secondary", label: "Secondary" },
+                  { variant: "ghost", label: "Ghost" },
                 ] as const
               ).map(({ variant, label }) => (
                 <SubSection key={variant} title={label}>
                   <div className="flex flex-wrap items-center gap-4">
                     <div className="flex flex-col items-start gap-1">
-                      <Button variant={variant} size="sm">{label}</Button>
+                      <Button variant={variant} size="sm">
+                        {label}
+                      </Button>
                       <Label>size=sm</Label>
                     </div>
                     <div className="flex flex-col items-start gap-1">
-                      <Button variant={variant} size="md">{label}</Button>
+                      <Button variant={variant} size="md">
+                        {label}
+                      </Button>
                       <Label>size=md</Label>
                     </div>
                     <div className="flex flex-col items-start gap-1">
-                      <Button variant={variant} size="lg">{label}</Button>
+                      <Button variant={variant} size="lg">
+                        {label}
+                      </Button>
                       <Label>size=lg</Label>
                     </div>
                     <div className="flex flex-col items-start gap-1">
-                      <Button variant={variant} size="md" disabled>{label}</Button>
+                      <Button variant={variant} size="md" disabled>
+                        {label}
+                      </Button>
                       <Label>disabled</Label>
                     </div>
                   </div>
@@ -463,10 +635,18 @@ function DesignSystemPage() {
 
               <SubSection title="Icon">
                 <div className="flex flex-wrap items-center gap-4">
-                  {(['sm', 'md', 'lg'] as const).map((size) => (
-                    <div key={size} className="flex flex-col items-center gap-1">
+                  {(["sm", "md", "lg"] as const).map((size) => (
+                    <div
+                      key={size}
+                      className="flex flex-col items-center gap-1"
+                    >
                       <Button variant="icon" size={size} aria-label="Play">
-                        <svg viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4" aria-hidden="true">
+                        <svg
+                          viewBox="0 0 16 16"
+                          fill="currentColor"
+                          className="w-4 h-4"
+                          aria-hidden="true"
+                        >
                           <path d="M3 2.75A.75.75 0 0 1 4.224 2.1l10 5.25a.75.75 0 0 1 0 1.3l-10 5.25A.75.75 0 0 1 3 13.25v-10.5Z" />
                         </svg>
                       </Button>
@@ -488,20 +668,28 @@ function DesignSystemPage() {
             <div className="flex flex-col gap-6">
               {(
                 [
-                  { variant: 'default', label: 'Default', content: 'Drama' },
-                  { variant: 'new', label: 'New', content: 'NEW' },
-                  { variant: 'live', label: 'Live', content: 'LIVE' },
-                  { variant: 'rating', label: 'Rating', content: '8.5' },
+                  {
+                    variant: "secondary",
+                    label: "Secondary",
+                    content: "Drama",
+                  },
+                  { variant: "new", label: "New", content: "NEW" },
+                  { variant: "live", label: "Live", content: "LIVE" },
+                  { variant: "rating", label: "Rating", content: "8.5" },
                 ] as const
               ).map(({ variant, label, content }) => (
                 <SubSection key={variant} title={label}>
                   <div className="flex flex-wrap items-center gap-4">
                     <div className="flex flex-col items-start gap-1">
-                      <Badge variant={variant} size="sm">{content}</Badge>
+                      <Badge variant={variant} size="sm">
+                        {content}
+                      </Badge>
                       <Label>size=sm</Label>
                     </div>
                     <div className="flex flex-col items-start gap-1">
-                      <Badge variant={variant} size="md">{content}</Badge>
+                      <Badge variant={variant} size="md">
+                        {content}
+                      </Badge>
                       <Label>size=md</Label>
                     </div>
                   </div>
@@ -518,7 +706,6 @@ function DesignSystemPage() {
             description="Loading placeholders. All use opacity-pulse animation (no transform) to keep layout stable during loading."
           >
             <div className="flex flex-col gap-8">
-
               <SubSection title="Text variant">
                 <div className="flex flex-col gap-4 max-w-sm">
                   <div>
@@ -545,7 +732,10 @@ function DesignSystemPage() {
                 <Label>Card (full-width, aspect-video)</Label>
               </SubSection>
 
-              <SubSection title="Avatar variant" className="flex flex-wrap gap-6 items-end">
+              <SubSection
+                title="Avatar variant"
+                className="flex flex-wrap gap-6 items-end"
+              >
                 <div>
                   <Skeleton variant="avatar" />
                   <Label>Avatar default (w-10 h-10)</Label>
@@ -560,7 +750,10 @@ function DesignSystemPage() {
                 </div>
               </SubSection>
 
-              <SubSection title="Composed — Card loading skeleton" className="max-w-xs">
+              <SubSection
+                title="Composed — Card loading skeleton"
+                className="max-w-xs"
+              >
                 <div className="flex flex-col gap-3">
                   <Skeleton variant="card" />
                   <Skeleton variant="text" className="w-3/4" />
@@ -583,28 +776,34 @@ function DesignSystemPage() {
                 <Button
                   variant="secondary"
                   size="md"
-                  onClick={() => error('Failed to load stream. Please try again.')}
+                  onClick={() =>
+                    error("Failed to load stream. Please try again.")
+                  }
                 >
                   Trigger Error
                 </Button>
                 <Button
                   variant="secondary"
                   size="md"
-                  onClick={() => warning('Your session will expire in 5 minutes.')}
+                  onClick={() =>
+                    warning("Your session will expire in 5 minutes.")
+                  }
                 >
                   Trigger Warning
                 </Button>
                 <Button
                   variant="secondary"
                   size="md"
-                  onClick={() => info('New content available in your favorites.')}
+                  onClick={() =>
+                    info("New content available in your favorites.")
+                  }
                 >
                   Trigger Info
                 </Button>
                 <Button
                   variant="secondary"
                   size="md"
-                  onClick={() => success('Added to favorites.')}
+                  onClick={() => success("Added to favorites.")}
                 >
                   Trigger Success
                 </Button>
@@ -617,16 +816,32 @@ function DesignSystemPage() {
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   {(
                     [
-                      { label: 'error', border: 'border-error/50 bg-error/10 text-error', icon: '✕' },
-                      { label: 'warning', border: 'border-warning/50 bg-warning/10 text-warning', icon: '⚠' },
-                      { label: 'info', border: 'border-info/50 bg-info/10 text-info', icon: 'ℹ' },
-                      { label: 'success', border: 'border-success/50 bg-success/10 text-success', icon: '✓' },
+                      {
+                        label: "error",
+                        border: "border-error/50 bg-error/10 text-error",
+                        icon: "✕",
+                      },
+                      {
+                        label: "warning",
+                        border: "border-warning/50 bg-warning/10 text-warning",
+                        icon: "⚠",
+                      },
+                      {
+                        label: "info",
+                        border: "border-info/50 bg-info/10 text-info",
+                        icon: "ℹ",
+                      },
+                      {
+                        label: "success",
+                        border: "border-success/50 bg-success/10 text-success",
+                        icon: "✓",
+                      },
                     ] as const
                   ).map(({ label, border, icon }) => (
                     <div
                       key={label}
                       className={cn(
-                        'flex items-center gap-3 px-4 py-2.5 rounded-[var(--radius-md)] border text-sm font-medium',
+                        "flex items-center gap-3 px-4 py-2.5 rounded-[var(--radius-md)] border text-sm font-medium",
                         border,
                       )}
                     >
@@ -647,7 +862,6 @@ function DesignSystemPage() {
             description="Three card variants for different content layouts. All use memo(), specific CSS transitions, and have image fallback states."
           >
             <div className="flex flex-col gap-10">
-
               <SubSection
                 title="PosterCard — 2:3 aspect, for VOD and series grids"
                 className="flex flex-wrap gap-6"
@@ -718,18 +932,22 @@ function DesignSystemPage() {
                 </div>
               </SubSection>
 
-              <SubSection
-                title="HeroCard — full-width featured slot with brand gradient fallback"
-              >
+              <SubSection title="HeroCard — full-width featured slot with brand gradient fallback">
                 <HeroCard
                   title="Pushpa 2: The Rule"
                   description="The rule continues. Pushpa Raj expands his sandalwood empire and faces a new, deadlier nemesis. A story of power, loyalty, and defiance."
                   imageUrl=""
                 >
-                  <Button variant="primary" size="md">Watch Now</Button>
-                  <Button variant="secondary" size="md">More Info</Button>
+                  <Button variant="primary" size="md">
+                    Watch Now
+                  </Button>
+                  <Button variant="secondary" size="md">
+                    More Info
+                  </Button>
                 </HeroCard>
-                <Label>imageUrl="" → brand gradient fallback. Children = CTA buttons.</Label>
+                <Label>
+                  imageUrl="" → brand gradient fallback. Children = CTA buttons.
+                </Label>
               </SubSection>
             </div>
           </Section>
@@ -754,17 +972,36 @@ function DesignSystemPage() {
               <SubSection title="Token reference">
                 <div className="flex flex-col gap-2">
                   {[
-                    { name: '--shadow-focus', value: '0 0 0 2px rgba(20,184,166,0.6)', desc: 'Desktop focus ring' },
-                    { name: '--shadow-focus-tv', value: '0 0 0 3px rgba(20,184,166,0.8), 0 0 20px rgba(20,184,166,0.15)', desc: 'TV focus ring (thicker + glow)' },
-                    { name: '--color-focus', value: '#14b8a6', desc: 'Focus ring base color (= accent-teal)' },
+                    {
+                      name: "--shadow-focus",
+                      value: "0 0 0 2px rgba(20,184,166,0.6)",
+                      desc: "Desktop focus ring",
+                    },
+                    {
+                      name: "--shadow-focus-tv",
+                      value:
+                        "0 0 0 3px rgba(20,184,166,0.8), 0 0 20px rgba(20,184,166,0.15)",
+                      desc: "TV focus ring (thicker + glow)",
+                    },
+                    {
+                      name: "--color-focus",
+                      value: "#14b8a6",
+                      desc: "Focus ring base color (= accent-teal)",
+                    },
                   ].map(({ name, value, desc }) => (
                     <div
                       key={name}
                       className="flex items-start gap-4 py-2.5 px-3 rounded-[var(--radius-sm)] bg-bg-tertiary border border-white/6"
                     >
-                      <code className="text-xs font-mono text-accent-teal shrink-0 w-44">{name}</code>
-                      <code className="text-xs font-mono text-text-secondary flex-1 break-all">{value}</code>
-                      <span className="text-xs text-text-tertiary shrink-0 w-44 text-right">{desc}</span>
+                      <code className="text-xs font-mono text-accent-teal shrink-0 w-44">
+                        {name}
+                      </code>
+                      <code className="text-xs font-mono text-text-secondary flex-1 break-all">
+                        {value}
+                      </code>
+                      <span className="text-xs text-text-tertiary shrink-0 w-44 text-right">
+                        {desc}
+                      </span>
                     </div>
                   ))}
                 </div>
@@ -782,34 +1019,36 @@ function DesignSystemPage() {
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               {[
                 {
-                  name: 'AppErrorBoundary',
-                  scope: 'Application root',
-                  placement: 'Wraps <Outlet /> in __root.tsx',
+                  name: "AppErrorBoundary",
+                  scope: "Application root",
+                  placement: "Wraps <Outlet /> in __root.tsx",
                   recovery: '"Reload App" button → window.location.reload()',
-                  display: 'Full-page centered card',
-                  color: 'border-error/30 bg-error/5',
+                  display: "Full-page centered card",
+                  color: "border-error/30 bg-error/5",
                 },
                 {
-                  name: 'RouteErrorBoundary',
-                  scope: 'Individual route',
-                  placement: 'Wraps route component or page tree',
-                  recovery: '"Go Back" (history.back) + "Try Again" (resets state)',
-                  display: 'Inline card, min-h-[400px]',
-                  color: 'border-warning/30 bg-warning/5',
+                  name: "RouteErrorBoundary",
+                  scope: "Individual route",
+                  placement: "Wraps route component or page tree",
+                  recovery:
+                    '"Go Back" (history.back) + "Try Again" (resets state)',
+                  display: "Inline card, min-h-[400px]",
+                  color: "border-warning/30 bg-warning/5",
                 },
                 {
-                  name: 'PlayerErrorBoundary',
-                  scope: 'Video player',
-                  placement: 'Wraps <PlayerPage /> in FullscreenPlayer',
-                  recovery: '"Retry" resets state, "Close" calls onClose() prop',
-                  display: 'Dark overlay matching player UI',
-                  color: 'border-info/30 bg-info/5',
+                  name: "PlayerErrorBoundary",
+                  scope: "Video player",
+                  placement: "Wraps <PlayerPage /> in FullscreenPlayer",
+                  recovery:
+                    '"Retry" resets state, "Close" calls onClose() prop',
+                  display: "Dark overlay matching player UI",
+                  color: "border-info/30 bg-info/5",
                 },
               ].map(({ name, scope, placement, recovery, display, color }) => (
                 <div
                   key={name}
                   className={cn(
-                    'rounded-[var(--radius-lg)] border p-5 flex flex-col gap-3',
+                    "rounded-[var(--radius-lg)] border p-5 flex flex-col gap-3",
                     color,
                   )}
                 >
@@ -818,16 +1057,18 @@ function DesignSystemPage() {
                   </h4>
                   <dl className="flex flex-col gap-2">
                     {[
-                      { dt: 'Scope', dd: scope },
-                      { dt: 'Placement', dd: placement },
-                      { dt: 'Recovery', dd: recovery },
-                      { dt: 'Display', dd: display },
+                      { dt: "Scope", dd: scope },
+                      { dt: "Placement", dd: placement },
+                      { dt: "Recovery", dd: recovery },
+                      { dt: "Display", dd: display },
                     ].map(({ dt, dd }) => (
                       <div key={dt}>
                         <dt className="text-xs font-semibold text-text-tertiary uppercase tracking-wide mb-0.5">
                           {dt}
                         </dt>
-                        <dd className="text-xs text-text-secondary leading-snug">{dd}</dd>
+                        <dd className="text-xs text-text-secondary leading-snug">
+                          {dd}
+                        </dd>
                       </div>
                     ))}
                   </dl>
@@ -836,8 +1077,12 @@ function DesignSystemPage() {
             </div>
 
             <p className="mt-4 text-xs text-text-tertiary font-[family-name:var(--font-family-body)] leading-relaxed">
-              All boundaries only show the raw error message in <code className="font-mono text-accent-teal">import.meta.env.DEV</code> mode.
-              Production renders only the recovery UI — no internal details exposed.
+              All boundaries only show the raw error message in{" "}
+              <code className="font-mono text-accent-teal">
+                import.meta.env.DEV
+              </code>{" "}
+              mode. Production renders only the recovery UI — no internal
+              details exposed.
             </p>
           </Section>
 
@@ -849,18 +1094,37 @@ function DesignSystemPage() {
             description="All transition durations and z-index values are CSS custom properties. Never use transition-all — always specify exact properties."
           >
             <div className="flex flex-col gap-8">
-              <SubSection title="Transition Tokens" className="flex flex-col gap-2">
+              <SubSection
+                title="Transition Tokens"
+                className="flex flex-col gap-2"
+              >
                 {[
-                  { name: '--transition-fast', value: '150ms ease-out', usage: 'Hover states, badge color changes' },
-                  { name: '--transition-normal', value: '200ms ease-out', usage: 'Card scale, focus ring, overlays' },
-                  { name: '--transition-slow', value: '300ms ease-out', usage: 'Page-level transitions' },
+                  {
+                    name: "--transition-fast",
+                    value: "150ms ease-out",
+                    usage: "Hover states, badge color changes",
+                  },
+                  {
+                    name: "--transition-normal",
+                    value: "200ms ease-out",
+                    usage: "Card scale, focus ring, overlays",
+                  },
+                  {
+                    name: "--transition-slow",
+                    value: "300ms ease-out",
+                    usage: "Page-level transitions",
+                  },
                 ].map(({ name, value, usage }) => (
                   <div
                     key={name}
                     className="flex items-center gap-4 py-2.5 px-3 rounded-[var(--radius-sm)] bg-bg-tertiary border border-white/6"
                   >
-                    <code className="text-xs font-mono text-accent-teal shrink-0 w-44">{name}</code>
-                    <code className="text-xs font-mono text-text-secondary shrink-0 w-36">{value}</code>
+                    <code className="text-xs font-mono text-accent-teal shrink-0 w-44">
+                      {name}
+                    </code>
+                    <code className="text-xs font-mono text-text-secondary shrink-0 w-36">
+                      {value}
+                    </code>
                     <span className="text-xs text-text-tertiary">{usage}</span>
                   </div>
                 ))}
@@ -868,27 +1132,50 @@ function DesignSystemPage() {
 
               <SubSection title="Z-Index Scale" className="flex flex-col gap-2">
                 {[
-                  { name: '--z-base', value: '0', usage: 'Default content' },
-                  { name: '--z-dropdown', value: '10', usage: 'Dropdowns, menus' },
-                  { name: '--z-sticky', value: '20', usage: 'Sticky nav, TopNav' },
-                  { name: '--z-overlay', value: '30', usage: 'Sheet overlays, backdrop' },
-                  { name: '--z-modal', value: '40', usage: 'Dialogs, modals' },
-                  { name: '--z-toast', value: '50', usage: 'Toast notifications (ToastContainer)' },
-                  { name: '--z-player', value: '60', usage: 'Fullscreen video player' },
+                  { name: "--z-base", value: "0", usage: "Default content" },
+                  {
+                    name: "--z-dropdown",
+                    value: "10",
+                    usage: "Dropdowns, menus",
+                  },
+                  {
+                    name: "--z-sticky",
+                    value: "20",
+                    usage: "Sticky nav, TopNav",
+                  },
+                  {
+                    name: "--z-overlay",
+                    value: "30",
+                    usage: "Sheet overlays, backdrop",
+                  },
+                  { name: "--z-modal", value: "40", usage: "Dialogs, modals" },
+                  {
+                    name: "--z-toast",
+                    value: "50",
+                    usage: "Toast notifications (ToastContainer)",
+                  },
+                  {
+                    name: "--z-player",
+                    value: "60",
+                    usage: "Fullscreen video player",
+                  },
                 ].map(({ name, value, usage }) => (
                   <div
                     key={name}
                     className="flex items-center gap-4 py-2.5 px-3 rounded-[var(--radius-sm)] bg-bg-tertiary border border-white/6"
                   >
-                    <code className="text-xs font-mono text-accent-teal shrink-0 w-36">{name}</code>
-                    <code className="text-xs font-mono text-text-secondary shrink-0 w-8">{value}</code>
+                    <code className="text-xs font-mono text-accent-teal shrink-0 w-36">
+                      {name}
+                    </code>
+                    <code className="text-xs font-mono text-text-secondary shrink-0 w-8">
+                      {value}
+                    </code>
                     <span className="text-xs text-text-tertiary">{usage}</span>
                   </div>
                 ))}
               </SubSection>
             </div>
           </Section>
-
         </div>
 
         {/* Footer */}
@@ -896,9 +1183,10 @@ function DesignSystemPage() {
           <p className="text-xs text-text-tertiary font-mono">
             /dev/design-system — StreamVault v2.0 Sprint 0
           </p>
-          <Badge variant="default" size="sm">Developer Only</Badge>
+          <Badge variant="secondary" size="sm">
+            Developer Only
+          </Badge>
         </div>
-
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Button**: Added `isTVFocused` prop — thick teal ring + ambient glow visible at 10-foot TV viewing distance; `box-shadow` added to transition list for smooth animation
- **Badge**: Added `lg` size; new `primary`, `secondary`, `status` variants (with `statusColor` sub-prop for semantic status colors); existing `new`, `live`, `rating` variants preserved
- **Input** (new): default / error / disabled states using design-system tokens; label, startAdornment, isTVFocused support; error message via `role="alert"`
- **Toggle** (new): on/off slide animation (thumb translates on checked); all sizes (sm/md/lg); `isTVFocused` ring visible at 10ft; backed by `sr-only` checkbox for full accessibility; `role="switch"` + `aria-checked`
- All 4 components use design-system tokens only (zero old CSS)
- `primitives/index.ts` updated with all new exports

## Test plan

- [x] `npm test` — 101 tests passing (was 84 before this PR, +17 new tests across all 4 components)
- [x] Button TV-focus: `isTVFocused=true` applies teal ring class
- [x] Badge: `primary`, `secondary`, `status` variants render correct token classes; `lg` size uses `text-base px-3`
- [x] Input: error state shows `border-error` + `role="alert"` message; disabled applies `opacity-50 cursor-not-allowed`
- [x] Toggle: `checked=true` applies `bg-accent-teal` on track; `disabled` forwards attribute; `onChange` fires on click
- [x] TypeScript build clean (no type errors introduced)

Closes [SRI-33](/SRI/issues/SRI-33)