### PR TITLE
fix(root): PlayerShell lazy import for named export

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -15,8 +15,10 @@ import { lazy, Suspense, useEffect } from "react";
 // PlayerShell renders nothing when status==="idle", so deferring it has
 // zero visual impact on first page load. The chunk is prefetched immediately
 // after the initial render, so it is ready before the user plays anything.
-const PlayerShell = lazy(
-  () => import("@features/player/components/PlayerShell"),
+const PlayerShell = lazy(() =>
+  import("@features/player/components/PlayerShell").then((m) => ({
+    default: m.PlayerShell,
+  })),
 );
 
 export const Route = createRootRoute({


### PR DESCRIPTION
## Summary
- PlayerShell uses named export (`export function PlayerShell`), not default
- `React.lazy()` requires `{ default: ComponentType }` — needs `.then()` wrapper
- Lost during conflict resolution when merging PR #202/#203

## Test plan
- [x] `tsc --noEmit` passes locally
- [ ] Docker build succeeds (was failing without this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)