### PR TITLE
docs: ARCHIVED banner — streamvault-frontend is v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# ARCHIVED — StreamVault v2 (streamvault-frontend)
+
+> **Status:** ARCHIVED as of 2026-04-15. Do not resume work on this repo.
+>
+> **Replacement:** See [streamvault-v3-frontend](https://github.com/srinivas-kotha/streamvault-v3-frontend) for the v3 clean-reset rewrite.
+>
+> **Why archived:**
+> - v2 accumulated two overlapping sprint tracks (SV-S* + SV-Redesign S*) that caused process drift and duplicate work.
+> - v3 is a fresh repo with locked architecture: React 19 + Vite 5 + Tailwind 4 + norigin-spatial-navigation 2.1.0, TV-first Fire TV 4K Max, Oxide palette on gunmetal.
+> - Plan: `docs/superpowers/plans/2026-04-15-streamvault-v3-implementation.md` (claude-dotfiles, PR #295).
+>
+> **Production note:** This repo's build continues to serve prod until v3 MVP ships (~10.6 weeks focused / 13-14 realistic).
+>
+> **Historical reference only.** Bugs should NOT be filed here. File against `streamvault-v3-frontend` instead.
+
+---
+


### PR DESCRIPTION
## Summary
- Adds ARCHIVED banner as README.md
- Redirects future readers to streamvault-v3-frontend (v3 clean-reset)
- Prepares repo for rename to streamvault-v2-archived

## Context
- v3 plan locked via claude-dotfiles PR #295 (4.72/5.0 PASS)
- Phase 0 Task 0.2 of v3 plan: push banner BEFORE rename (m1 fix)

## Test plan
- [x] README reads as archive notice
- [ ] Merge then `gh repo rename streamvault-frontend streamvault-v2-archived`

🤖 Generated with [Claude Code](https://claude.com/claude-code)