### PR TITLE
fix(gitignore): exclude .superpowers/ plugin state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ blob-report/
 # Lighthouse raw reports (keep summary.json, ignore per-page detail files ~1MB each)
 tests/e2e/lighthouse-results/*.json
 !tests/e2e/lighthouse-results/summary.json
+
+# Claude Code plugin state (not source)
+.superpowers/


### PR DESCRIPTION
## Summary
- Adds `.superpowers/` to `.gitignore` — auto-created by Claude Code superpowers plugin, not part of source

## Test plan
- [x] `.superpowers/` no longer shows in `git status`